### PR TITLE
#43803 Addresses publish2 slowness by preventing unnecessary queries

### DIFF
--- a/python/tk_multi_publish2/context_widget/context_widget.py
+++ b/python/tk_multi_publish2/context_widget/context_widget.py
@@ -362,8 +362,8 @@ class ContextWidget(QtGui.QWidget):
         task_actions = []
 
         for task in tasks:
-            task_context = publisher.sgtk.context_from_entity_dictionary(
-                task)
+            task_context = publisher.sgtk.context_from_entity_dictionary(task)
+
             # the context from dict method clears all unnecessary fields
             # from the task upon creation. now that we have the context,
             # update the fields with the queried task fields
@@ -695,7 +695,7 @@ class ContextWidget(QtGui.QWidget):
             [["entity", "is", context.entity]],
             # query all fields required to create a context from a task entity
             # dictionary. see sgtk api `context_from_entity_dictionary`
-            fields=["type", "id", "name", "project", "entity", "step"]
+            fields=["type", "id", "name", "content", "project", "entity", "step"]
         )
 
         # cache the tasks
@@ -911,7 +911,10 @@ def _query_my_tasks():
         # query all fields required to create a context from a task entity
         # dictionary. see sgtk api `context_from_entity_dictionary`
         fields=[
+            "type",
+            "id",
             "name",
+            "content",
             "project",
             "entity",
             "step",

--- a/python/tk_multi_publish2/context_widget/context_widget.py
+++ b/python/tk_multi_publish2/context_widget/context_widget.py
@@ -27,6 +27,17 @@ settings = sgtk.platform.import_framework(
 
 logger = sgtk.platform.get_logger(__name__)
 
+# fields required to create a context from a task entity without falling back to
+# a SG query
+TASK_QUERY_FIELDS =[
+    "type",
+    "id",
+    "content",
+    "project",
+    "entity",
+    "step"
+]
+
 
 class ContextWidget(QtGui.QWidget):
     """
@@ -695,7 +706,7 @@ class ContextWidget(QtGui.QWidget):
             [["entity", "is", context.entity]],
             # query all fields required to create a context from a task entity
             # dictionary. see sgtk api `context_from_entity_dictionary`
-            fields=["type", "id", "name", "content", "project", "entity", "step"]
+            fields=TASK_QUERY_FIELDS
         )
 
         # cache the tasks
@@ -905,22 +916,15 @@ def _query_my_tasks():
         {"field_name": "content", "direction": "asc"}
     ]
 
+    # query all fields required to create a context from a task entity
+    # dictionary. see sgtk api `context_from_entity_dictionary`
+    task_fields = TASK_QUERY_FIELDS
+    task_fields.extend(["sg_status_list"])
+
     return publisher.shotgun.find(
         "Task",
         filters,
-        # query all fields required to create a context from a task entity
-        # dictionary. see sgtk api `context_from_entity_dictionary`
-        fields=[
-            "type",
-            "id",
-            "name",
-            "content",
-            "project",
-            "entity",
-            "step",
-            "content",
-            "sg_status_list"
-        ],
+        fields=task_fields,
         order=order
     )
 


### PR DESCRIPTION
The "related" tasks background query was supposed to prevent unnecessary
SG queries by querying all fields required by `context.from_entity_dictionary`.
Unfortunately, the core docs had the field "name" instead of "context" and I
never tested to make sure that additional queries weren't happening. I've updated
the core docs separately and this adds the "context" field to the query which
appears to speed up the item selection.