### PR TITLE
retain items of type TopLevelTreeNodeItem only when performing drag o…

### DIFF
--- a/python/tk_multi_publish2/publish_tree_widget/publish_tree_widget.py
+++ b/python/tk_multi_publish2/publish_tree_widget/publish_tree_widget.py
@@ -436,10 +436,11 @@ class PublishTreeWidget(QtGui.QTreeWidget):
         # retain only TopLevelTreeNodeItems items from selected elements
         for item in self.selectedItems():
             if isinstance(item, TopLevelTreeNodeItem):
-                dragged_items.append(item)
+                dragged_items.append(item) 
 
         # ignore any selection that does not contain at least one TopLevelTreeNodeItems
-        if(len(dragged_items)==0):
+        if not dragged_items:
+            logger.debug("No top-level nodes included in selection.")        
             return
 
         # extract state

--- a/python/tk_multi_publish2/publish_tree_widget/publish_tree_widget.py
+++ b/python/tk_multi_publish2/publish_tree_widget/publish_tree_widget.py
@@ -431,13 +431,16 @@ class PublishTreeWidget(QtGui.QTreeWidget):
         """
         # record selection for use later.
         self._dragged_items = []
-        dragged_items = self.selectedItems()
+        dragged_items = []
 
-        # ignore any selections which aren't purely made from TopLevelTreeNodeItems
-        for item in dragged_items:
-            if not isinstance(item, TopLevelTreeNodeItem):
-                logger.debug("Selection contains non-top level nodes. Ignoring")
-                return
+        # retain only TopLevelTreeNodeItems items from selected elements
+        for item in self.selectedItems():
+            if isinstance(item, TopLevelTreeNodeItem):
+                dragged_items.append(item)
+
+        # ignore any selection that does not contain at least one TopLevelTreeNodeItems
+        if(len(dragged_items)==0):
+            return
 
         # extract state
         for item in dragged_items:


### PR DESCRIPTION
#43792 PublishTreeWidget rejects drag/drop operations if the selection contains items that are not TopLevelTreeNodeItem. As a result if user shift-selects assets and underlying actions in the publish view, the drag/drop operations fails because of the selected actions. Fix: Modified the behavior of drag operation to consider only elements derived from TopLevelTreeNodeItem, ignoring items of other types.