### PR TITLE
#43896 description inheritance bug

### DIFF
--- a/python/tk_multi_publish2/dialog.py
+++ b/python/tk_multi_publish2/dialog.py
@@ -19,6 +19,7 @@ from .processing import PluginManager, Task, Item
 from .progress import ProgressHandler
 from .summary_overlay import SummaryOverlay
 from .publish_tree_widget import TreeNodeItem
+from .publish_description_edit import PublishDescriptionEdit
 
 
 # import frameworks
@@ -270,6 +271,7 @@ class AppDialog(QtGui.QWidget):
 
                 # all tasks have same description now, so set <multiple values> indicator to false
                 self._summary_comment_multiple_values = False
+                self.ui.item_comments._show_placeholder = self._summary_comment_multiple_values
         else:
             self._current_item.description = comments
 
@@ -366,12 +368,12 @@ class AppDialog(QtGui.QWidget):
 
         self.ui.item_description_label.setText("Description to apply to all items")
         self.ui.item_comments.setPlainText(self._summary_comment)
-        self._summary_comment_multiple_values = True
-        if self._summary_comment_multiple_values == True:
-            self.ui.item_comments.setPlaceholderText("<multiple values>")
-            self.setFocus()
-        else:
-            self.ui.item_comments.setPlaceholderText("")
+
+        # the item_comments PublishDescriptionFocus won't display placeholder text if it is in focus
+        # so clearing the focus from that widget in order to see the <multiple values> warning once 
+        # the master summary details page is opened
+        self.ui.item_comments.clearFocus()
+        self.ui.item_comments._show_placeholder = self._summary_comment_multiple_values
 
         # for the summary, attempt to display the appropriate context in the
         # context widget. if all publish items have the same context, display

--- a/python/tk_multi_publish2/publish_description_edit.py
+++ b/python/tk_multi_publish2/publish_description_edit.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2017 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import sgtk
+from sgtk.platform.qt import QtCore, QtGui
+
+logger = sgtk.platform.get_logger(__name__)
+
+class PublishDescriptionEdit(QtGui.QPlainTextEdit):
+    """
+    Widget that holds the summary description
+    """
+
+    def __init__(self, parent):
+        """
+        Constructor
+        
+        :param parent: QT parent object
+        """
+        QtGui.QPlainTextEdit.__init__(self, parent)
+
+        self._show_placeholder = False
+
+        #this is theplaceholder text to be displayed in the bottom right corner of the widget. The spaces afterwards were added so that the 
+        # placeholder text won't be hidden behind the scroll bar that is automatically added when the text is too long 
+        self._placeholder_text = "<multiple values>      "
+
+    def paintEvent(self, paint_event):
+       """
+       Paints the line plain text editor and adds a placeholder on bottom right corner when multiple values are detected.
+       """
+ 
+       # If the box does not have focus, draw <multiple values> placeholder when self._show_placeholder is true, even if the widget has text
+       if not self.hasFocus() and self._show_placeholder == True:
+ 
+           # draw the original text (summary description)
+           QtGui.QPlainTextEdit.paintEvent(self, paint_event)
+
+           p = QtGui.QPainter(self.viewport())
+
+           # draw transparent rectangle to slightly hide the text
+           background_color = p.background().color()
+           background_color.setAlpha(128)
+           p.fillRect(self.rect(), QtGui.QBrush(background_color));
+
+           # right placeholder warning in red
+           col = QtGui.QColor("#FF2D5B") #red
+           p.setPen(QtGui.QPen(col))
+           p.setBrush(QtGui.QBrush(col))
+           p.drawText(self.rect(),QtCore.Qt.AlignBottom | QtCore.Qt.AlignRight, self._placeholder_text)
+ 
+       else:
+           QtGui.QPlainTextEdit.paintEvent(self, paint_event)

--- a/python/tk_multi_publish2/ui/dialog.py
+++ b/python/tk_multi_publish2/ui/dialog.py
@@ -193,7 +193,7 @@ class Ui_Dialog(object):
         self.item_thumbnail_label = QtGui.QLabel(self.details_item)
         self.item_thumbnail_label.setObjectName("item_thumbnail_label")
         self.gridLayout_3.addWidget(self.item_thumbnail_label, 0, 0, 1, 1)
-        self.item_comments = QtGui.QPlainTextEdit(self.details_item)
+        self.item_comments = PublishDescriptionEdit(self.details_item)
         sizePolicy = QtGui.QSizePolicy(QtGui.QSizePolicy.Expanding, QtGui.QSizePolicy.Preferred)
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
@@ -501,6 +501,7 @@ class Ui_Dialog(object):
 from ..thumbnail import Thumbnail
 from ..context_widget import ContextWidget
 from ..progress_status_label import ProgressStatusLabel
+from ..publish_description_edit import PublishDescriptionEdit
 from ..publish_tree_widget import PublishTreeWidget
 from ..settings_widget import SettingsWidget
 from ..drop_area import DropAreaFrame

--- a/resources/dialog.ui
+++ b/resources/dialog.ui
@@ -427,7 +427,7 @@
                      </widget>
                     </item>
                     <item row="1" column="1">
-                     <widget class="QPlainTextEdit" name="item_comments">
+                     <widget class="PublishDescriptionEdit" name="item_comments">
                       <property name="sizePolicy">
                        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
                         <horstretch>0</horstretch>
@@ -1026,6 +1026,12 @@
    <class>SettingsWidget</class>
    <extends>QWidget</extends>
    <header>..settings_widget</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>PublishDescriptionEdit</class>
+   <extends>QPlainTextEdit</extends>
+   <header>..publish_description_edit</header>
    <container>1</container>
   </customwidget>
   <customwidget>


### PR DESCRIPTION
-Fixed description inheritance bug. The bug occurred when the user writes down a summary description, selects a task, and then select the summary tab again and caused the summary description to be cleared.
-Created PublishDescriptionEdit widget to add placeholder text support to QPlainTextEdit. It allows to display <multiple values> warning to warn the user that if the summary description is edited, it is going to override the description that was specifically written for particular task(s).   