### PR TITLE
#43896 Removed placeholder text in child items

### DIFF
--- a/python/tk_multi_publish2/dialog.py
+++ b/python/tk_multi_publish2/dialog.py
@@ -270,9 +270,11 @@ class AppDialog(QtGui.QWidget):
 
                 # all tasks have same description now, so set <multiple values> indicator to false
                 self._summary_comment_multiple_values = False
-                self.ui.item_comments._show_placeholder = self._summary_comment_multiple_values
+
+            self.ui.item_comments._show_placeholder = self._summary_comment_multiple_values
         else:
             self._current_item.description = comments
+            self.ui.item_comments._show_placeholder = False
 
             # if at least one task has a comment that is different than the summary description, set 
             # <multiple values> indicator to true 

--- a/python/tk_multi_publish2/dialog.py
+++ b/python/tk_multi_publish2/dialog.py
@@ -260,6 +260,8 @@ class AppDialog(QtGui.QWidget):
         publish comments box in the overview details pane
         """
         comments = self.ui.item_comments.toPlainText()
+        
+        # if this is the summary description...
         if self._current_item is None:
             if self._summary_comment != comments:
                 self._summary_comment = comments
@@ -272,8 +274,12 @@ class AppDialog(QtGui.QWidget):
                 self._summary_comment_multiple_values = False
 
             self.ui.item_comments._show_placeholder = self._summary_comment_multiple_values
+
+        # the "else" below means if this is a publish item
         else:
             self._current_item.description = comments
+            
+            # <multiple values> placeholder text should not appear for individual items
             self.ui.item_comments._show_placeholder = False
 
             # if at least one task has a comment that is different than the summary description, set 


### PR DESCRIPTION
When Publish items have multiple descriptions, a "multiple values" placeholder text is displayed in the summary description. When individual items are selected, this placeholder text is erroneously displayed too, while it should not appear for individual publish items.