### PR TITLE
#43561 clean up paths after item deleted

### DIFF
--- a/python/tk_multi_publish2/processing/plugin_manager.py
+++ b/python/tk_multi_publish2/processing/plugin_manager.py
@@ -74,6 +74,15 @@ class PluginManager(object):
         """
         Removed the given item from the list of top level items
         """
+
+        # we must also remove the path from the list of dropped paths, so that it can be added again if chosen
+        path = item.properties.get("path")
+        try:
+            self._dropped_paths.remove(path)
+        except ValueError:
+            logger.warning("Item's path: %s could not be removed from dropped paths list: %s" % (path,
+                                                                                                self._dropped_paths))
+
         self._root_item.remove_item(item)
 
     @property


### PR DESCRIPTION
Fixed bug where the dropped paths were not cleared up when removing an item.
This meant that the user could not re-drop the file back into the publish window even after it had been removed.