### PR TITLE
#42764 fixed some errors that appeared when exception is launched during publishing

### DIFF
--- a/python/tk_multi_publish2/publish_tree_widget/custom_widget_context.py
+++ b/python/tk_multi_publish2/publish_tree_widget/custom_widget_context.py
@@ -49,7 +49,7 @@ class CustomTreeWidgetContext(CustomTreeWidgetBase):
         """
         pass
 
-    def set_status(self, status):
+    def set_status(self, status, message="", info_below=True):
         """
         Set the status for the plugin
         :param status: An integer representing on of the

--- a/python/tk_multi_publish2/publish_tree_widget/custom_widget_summary.py
+++ b/python/tk_multi_publish2/publish_tree_widget/custom_widget_summary.py
@@ -47,7 +47,7 @@ class CustomTreeWidgetSummary(CustomTreeWidgetBase):
         """
         pass
 
-    def set_status(self, status):
+    def set_status(self, status, message="", info_below=True):
         """
         Set the status for the plugin
         :param status: An integer representing on of the


### PR DESCRIPTION
Modified set_status() function arguments in CustomWidgetContext and CustomWidgetSummary to match the one in the base class (CustomTreeWidgetBase). This prevents additional errors from appearing in log file when an exception is launched during Publishing.