### PR TITLE
42849 open log view from overlay

### DIFF
--- a/python/tk_multi_publish2/dialog.py
+++ b/python/tk_multi_publish2/dialog.py
@@ -153,6 +153,7 @@ class AppDialog(QtGui.QWidget):
             self.ui.progress_bar
         )
 
+        # link the summary overlay status button with the log window
         self._overlay.ui.details.clicked.connect(self._progress_handler._progress_details.toggle)
 
         # hide settings for now

--- a/python/tk_multi_publish2/dialog.py
+++ b/python/tk_multi_publish2/dialog.py
@@ -153,6 +153,8 @@ class AppDialog(QtGui.QWidget):
             self.ui.progress_bar
         )
 
+        self._overlay.ui.details.clicked.connect(self._progress_handler._progress_details.toggle)
+
         # hide settings for now
         self.ui.item_settings_label.hide()
         self.ui.task_settings_label.hide()

--- a/python/tk_multi_publish2/summary_overlay.py
+++ b/python/tk_multi_publish2/summary_overlay.py
@@ -52,7 +52,7 @@ class SummaryOverlay(QtGui.QWidget):
             QtGui.QPixmap(":/tk_multi_publish2/publish_complete.png")
         )
         self.ui.label.setText("Publish\nComplete")
-        self.ui.details.setText("For more details, see the publish log")
+        self.ui.details.setText("For more details, click here")
         self.show()
 
     def show_fail(self):
@@ -63,7 +63,7 @@ class SummaryOverlay(QtGui.QWidget):
             QtGui.QPixmap(":/tk_multi_publish2/publish_failed.png")
         )
         self.ui.label.setText("Publish\nFailed!")
-        self.ui.details.setText("Please see error log for more details")
+        self.ui.details.setText("Click here for more details")
         self.show()
 
     def show_loading(self):

--- a/python/tk_multi_publish2/summary_overlay.py
+++ b/python/tk_multi_publish2/summary_overlay.py
@@ -52,7 +52,7 @@ class SummaryOverlay(QtGui.QWidget):
             QtGui.QPixmap(":/tk_multi_publish2/publish_complete.png")
         )
         self.ui.label.setText("Publish\nComplete")
-        self.ui.details.setText("For more details, click here")
+        self.ui.details.setText("For more details, <b>click here</b>.")
         self.show()
 
     def show_fail(self):
@@ -63,7 +63,7 @@ class SummaryOverlay(QtGui.QWidget):
             QtGui.QPixmap(":/tk_multi_publish2/publish_failed.png")
         )
         self.ui.label.setText("Publish\nFailed!")
-        self.ui.details.setText("Click here for more details")
+        self.ui.details.setText("For more details, <b>click here</b>.")
         self.show()
 
     def show_loading(self):

--- a/python/tk_multi_publish2/ui/summary_overlay.py
+++ b/python/tk_multi_publish2/ui/summary_overlay.py
@@ -2,6 +2,7 @@
 
 # Form implementation generated from reading ui file 'summary_overlay.ui'
 #
+# Created: Thu Oct 19 18:23:33 2017
 #      by: pyside-uic 0.2.15 running on PySide 1.2.2
 #
 # WARNING! All changes made in this file will be lost!
@@ -45,7 +46,7 @@ class Ui_SummaryOverlay(object):
         self.gridLayout.addItem(spacerItem2, 3, 1, 1, 1)
         spacerItem3 = QtGui.QSpacerItem(20, 46, QtGui.QSizePolicy.Minimum, QtGui.QSizePolicy.Expanding)
         self.gridLayout.addItem(spacerItem3, 0, 1, 1, 1)
-        self.details = QtGui.QLabel(self.summary_frame)
+        self.details = ProgressStatusLabel(self.summary_frame)
         self.details.setObjectName("details")
         self.gridLayout.addWidget(self.details, 2, 1, 1, 1)
         self.verticalLayout.addWidget(self.summary_frame)
@@ -58,4 +59,5 @@ class Ui_SummaryOverlay(object):
         self.label.setText(QtGui.QApplication.translate("SummaryOverlay", "TextLabel", None, QtGui.QApplication.UnicodeUTF8))
         self.details.setText(QtGui.QApplication.translate("SummaryOverlay", "TextLabel", None, QtGui.QApplication.UnicodeUTF8))
 
+from ..progress_status_label import ProgressStatusLabel
 from . import resources_rc

--- a/resources/summary_overlay.ui
+++ b/resources/summary_overlay.ui
@@ -118,7 +118,7 @@
        </spacer>
       </item>
       <item row="2" column="1">
-       <widget class="QLabel" name="details">
+       <widget class="ProgressStatusLabel" name="details">
         <property name="text">
          <string>TextLabel</string>
         </property>
@@ -129,6 +129,13 @@
    </item>
   </layout>
  </widget>
+  <customwidgets>
+  <customwidget>
+   <class>ProgressStatusLabel</class>
+   <extends>QLabel</extends>
+   <header>..progress_status_label</header>
+  </customwidget>
+ </customwidgets>
  <resources>
   <include location="resources.qrc"/>
  </resources>


### PR DESCRIPTION
Transformed the summary overlay status label into a clickable link that opens the log view.