### PR TITLE
For #35585, bugfixes for custom UI

### DIFF
--- a/python/tk_multi_publish2/dialog.py
+++ b/python/tk_multi_publish2/dialog.py
@@ -820,6 +820,10 @@ class AppDialog(QtGui.QWidget):
         """
         publish_failed = False
 
+        # Make sure that settings from the current selection are retrieved from the UI and applied
+        # back on the tasks.
+        self._pull_settings_from_ui(self._current_tasks)
+
         self._prepare_tree(number_phases=3)
 
         try:

--- a/tests/fixtures/config/hooks/plugin_with_ui.py
+++ b/tests/fixtures/config/hooks/plugin_with_ui.py
@@ -9,6 +9,7 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import abc
+import pprint
 
 import sgtk
 
@@ -372,7 +373,8 @@ class PluginWithUi(HookBaseClass):
             instances.
         :param item: Item to process
         """
-        self.logger.info("Plugin with UI data was published!")
+        print item, "was published! The settings were:"
+        pprint.pprint({k: v.value for k, v in settings.iteritems()})
 
     def finalize(self, settings, item):
         """


### PR DESCRIPTION
Since the settings are read back from the UI when the selection changes, we need to make sure that when the user clicks publish that the selection's settings are read back before the publish starts.

The test app will now print the settings during publish in the console for easier testing.