### PR TITLE
For #45524, alembic publish fix

### DIFF
--- a/hooks/publish_file.py
+++ b/hooks/publish_file.py
@@ -582,7 +582,8 @@ class BasicFilePublishPlugin(HookBaseClass):
         work_fields = []
         publish_path = None
 
-        if work_template:
+        # We need both work and publish template to be defined for template support to be enabled.
+        if work_template and publish_template:
             if work_template.validate(path):
                 work_fields = work_template.get_fields(path)
 
@@ -598,6 +599,11 @@ class BasicFilePublishPlugin(HookBaseClass):
                     "Used publish template to determine the publish path: %s" %
                     (publish_path,)
                 )
+        elif not work_template and publish_template:
+            self.logger.warning(
+                "Publish template (%s) was specified but a work template was not.",
+                publish_template
+            )
 
         if not publish_path:
             publish_path = path

--- a/hooks/publish_file.py
+++ b/hooks/publish_file.py
@@ -599,11 +599,9 @@ class BasicFilePublishPlugin(HookBaseClass):
                     "Used publish template to determine the publish path: %s" %
                     (publish_path,)
                 )
-        elif not work_template and publish_template:
-            self.logger.warning(
-                "Publish template (%s) was specified but a work template was not.",
-                publish_template
-            )
+        else:
+            self.logger.debug("publish_template: %s" % publish_template)
+            self.logger.debug("work_template: %s" % work_template)
 
         if not publish_path:
             publish_path = path


### PR DESCRIPTION
If no publish template is available for a published file, like SG Alembic Nodes who are published in place, then we don't need to extract fields and simply need to use to current path as is.