### PR TITLE
#45932 Makes items for selected tasks available to create widget hook method

### DIFF
--- a/python/tk_multi_publish2/dialog.py
+++ b/python/tk_multi_publish2/dialog.py
@@ -359,7 +359,16 @@ class AppDialog(QtGui.QWidget):
             logger.debug("Reusing custom ui from %s.", new_task_selection.plugin)
         else:
             logger.debug("Building a custom ui for %s.", new_task_selection.plugin)
-            widget = new_task_selection.plugin.run_create_settings_widget(self.ui.custom_settings_page)
+
+            # get a list of items for selected tasks. we'll pass these to the
+            # widget creation method
+            items_for_selected_tasks = set(
+                [task.item for task in new_task_selection])
+
+            widget = new_task_selection.plugin.run_create_settings_widget(
+                self.ui.custom_settings_page,
+                items_for_selected_tasks=items_for_selected_tasks
+            )
             self.ui.custom_settings_page.widget = widget
 
         # Update the UI with the settings from the current plugin.
@@ -1108,13 +1117,6 @@ class _TaskSelection(object):
             return self._tasks[0].plugin
         else:
             return None
-
-    @property
-    def tasks(self):
-        """
-        Returns the list of `processing.task.Task` objects for this selection.
-        """
-        return self._tasks
 
     def get_settings(self, widget):
         """

--- a/python/tk_multi_publish2/processing/plugin.py
+++ b/python/tk_multi_publish2/processing/plugin.py
@@ -8,6 +8,7 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
+import inspect
 import traceback
 import sgtk
 from contextlib import contextmanager
@@ -243,7 +244,7 @@ class PublishPlugin(PluginBase):
         """
         return self._settings
 
-    def run_create_settings_widget(self, parent):
+    def run_create_settings_widget(self, parent, items_for_selected_tasks=None):
         """
         Creates a custom widget to edit a plugin's settings.
 
@@ -251,7 +252,20 @@ class PublishPlugin(PluginBase):
         :type parent: :class:`QtGui.QWidget`
         """
         with self._handle_plugin_error(None, "Error laying out widgets: %s"):
-            return self._hook_instance.create_settings_widget(parent)
+
+            # see if the hook instance method expects the
+            # items_for_selected_tasks argument which was added after the
+            # initial release of the hook method.
+            method_args = inspect.getargspec(
+                self._hook_instance.create_settings_widget).args
+
+            if "items_for_selected_tasks" in method_args:
+                return self._hook_instance.create_settings_widget(
+                    parent,
+                    items_for_selected_tasks=items_for_selected_tasks
+                )
+            else:
+                return self._hook_instance.create_settings_widget(parent)
 
     def run_get_ui_settings(self, parent):
         """

--- a/tests/fixtures/config/hooks/plugin_with_ui.py
+++ b/tests/fixtures/config/hooks/plugin_with_ui.py
@@ -208,14 +208,21 @@ class PluginWithUi(HookBaseClass):
     Plugin for creating generic publishes in Shotgun
     """
 
-    def create_settings_widget(self, parent):
+    def create_settings_widget(self, parent, items_for_selected_tasks=None):
         """
         Creates a QT widget, parented below the given parent object, to
         provide viewing and editing capabilities for the given settings.
 
         :param parent: QWidget to parent the widget under
+        :param items_for_selected_tasks: Items associated with all selected tasks
         :return: QWidget with an editor for the given setting or None if no custom widget is desired.
         """
+
+        if items_for_selected_tasks:
+            self.logger.debug("Got items for selected tasks...")
+            for item in items_for_selected_tasks:
+                self.logger.debug(" Item: %s" % (item,))
+
         return CustomWidgetController(parent)
 
     def get_ui_settings(self, controller):


### PR DESCRIPTION
This change adds a keyword argument called `items_for_selected_tasks` to the `create_settings_widget` publish hook method. Originally I wanted to make the `tasks` themselves available, but we don't really expose that API. Let me know if you think we should expose the tasks instead. 

The publisher will inspect the hook method to see if it accepts the new argument so it *should* work with existing client code that does not have this kwarg. 

This change also includes some renaming of internal dialog members to help the code read a bit easier. 