### PR TITLE
#45629 Implemented thumbnail inheritance

### DIFF
--- a/python/tk_multi_publish2/dialog.py
+++ b/python/tk_multi_publish2/dialog.py
@@ -176,6 +176,10 @@ class AppDialog(QtGui.QWidget):
         self._plugin_manager = PluginManager(self._progress_handler.logger)
         self.ui.items_tree.set_plugin_manager(self._plugin_manager)
 
+        # this is the pixmap in the summary thumbnail
+        self._summary_thumbnail = None 
+
+        # set publish button text
         display_action_name = self._bundle.get_setting("display_action_name")
         self.ui.publish.setText(display_action_name)
 
@@ -467,8 +471,19 @@ class AppDialog(QtGui.QWidget):
         thumbnail pixmap
         """
         if not self._current_item:
-            raise TankError("No current item set!")
-        self._current_item.thumbnail = pixmap
+            # this is the summary item
+            self._summary_thumbnail = pixmap
+            if pixmap != None:
+                # update all items with the summary thumbnail
+                for top_level_item in self._plugin_manager.top_level_items:
+                    top_level_item.thumbnail = self._summary_thumbnail
+                    top_level_item.thumbnail_explicit = False
+                    top_level_item._propagate_thumbnail_to_children()
+        else: 
+            self._current_item.thumbnail = pixmap
+            # specify that the new thumbnail overrides the one inherited from summary
+            self._current_item.thumbnail_explicit = True 
+
 
     def _create_item_details(self, tree_item):
         """
@@ -503,7 +518,18 @@ class AppDialog(QtGui.QWidget):
 
         self.ui.item_description_label.setText("Description")
         self.ui.item_comments.setPlainText(item.description)
+
+        # if summary thumbnail is defined, item thumbnail should inherit it
+        # unless item thumbnail was set after summary thumbnail
+        if self._summary_thumbnail != None and not item.thumbnail_explicit:
+            item.thumbnail = self._summary_thumbnail
+        
+        self.ui.item_thumbnail._set_multiple_values_indicator(False)
         self.ui.item_thumbnail.set_thumbnail(item.thumbnail)
+        
+
+        # 45629 -> Items with default thumbnails should still be able to have override thumbnails set by the user
+        self.ui.item_thumbnail.setEnabled(True)
 
         if item.parent.is_root():
             self.ui.context_widget.show()
@@ -559,8 +585,20 @@ class AppDialog(QtGui.QWidget):
         self.ui.item_name.setText("%s Summary"%display_name)
         self.ui.item_icon.setPixmap(QtGui.QPixmap(":/tk_multi_publish2/icon_256.png"))
 
-        self.ui.item_thumbnail_label.hide()
-        self.ui.item_thumbnail.hide()
+        self.ui.item_thumbnail_label.show()
+        self.ui.item_thumbnail.show()
+
+        thumbnail_is_multiple_values = False
+        for top_level_item in self._plugin_manager.top_level_items:
+           if top_level_item._get_thumbnail_explicit_recursive():
+               thumbnail_is_multiple_values = True
+               break
+      
+        self.ui.item_thumbnail._set_multiple_values_indicator(thumbnail_is_multiple_values)
+        self.ui.item_thumbnail.set_thumbnail(self._summary_thumbnail)
+
+        # setting enabled to true to be able to take a snapshot to define the thumbnail 
+        self.ui.item_thumbnail.setEnabled(True)
 
         self.ui.item_description_label.setText("Description for all items")
         self.ui.item_comments.setPlainText(self._summary_comment)

--- a/python/tk_multi_publish2/dialog.py
+++ b/python/tk_multi_publish2/dialog.py
@@ -473,7 +473,7 @@ class AppDialog(QtGui.QWidget):
         if not self._current_item:
             # this is the summary item
             self._summary_thumbnail = pixmap
-            if pixmap != None:
+            if pixmap:
                 # update all items with the summary thumbnail
                 for top_level_item in self._plugin_manager.top_level_items:
                     top_level_item.thumbnail = self._summary_thumbnail
@@ -521,14 +521,14 @@ class AppDialog(QtGui.QWidget):
 
         # if summary thumbnail is defined, item thumbnail should inherit it
         # unless item thumbnail was set after summary thumbnail
-        if self._summary_thumbnail != None and not item.thumbnail_explicit:
+        if self._summary_thumbnail and not item.thumbnail_explicit:
             item.thumbnail = self._summary_thumbnail
         
         self.ui.item_thumbnail._set_multiple_values_indicator(False)
         self.ui.item_thumbnail.set_thumbnail(item.thumbnail)
         
 
-        # 45629 -> Items with default thumbnails should still be able to have override thumbnails set by the user
+        # Items with default thumbnails should still be able to have override thumbnails set by the user
         self.ui.item_thumbnail.setEnabled(True)
 
         if item.parent.is_root():

--- a/python/tk_multi_publish2/processing/item.py
+++ b/python/tk_multi_publish2/processing/item.py
@@ -54,6 +54,8 @@ class Item(object):
         self._expanded = True
         self._thumbnail_enabled = True
         self._allows_context_change = True
+        # the following var indicates that the current thumbnail overrides the summary one
+        self._thumbnail_explicit = False
 
     def __repr__(self):
         """
@@ -216,6 +218,22 @@ class Item(object):
 
     thumbnail_enabled = property(_get_thumbnail_enabled, _set_thumbnail_enabled)
 
+    def _get_thumbnail_explicit(self):
+        """
+        Flag to indicate that thumbnail has been explicitly set.
+        When this flag is on, the summary thumbnail should be ignored
+        For this this specific item.
+        """
+        return self._thumbnail_explicit
+
+    def _set_thumbnail_explicit(self, enabled):
+        """
+        Setter for _thumbnail_explicit
+        """
+        self._thumbnail_explicit = enabled
+
+    thumbnail_explicit = property(_get_thumbnail_explicit,_set_thumbnail_explicit)
+
     def _get_context(self):
         """
         The context associated with this item.
@@ -256,9 +274,30 @@ class Item(object):
         propagate description to children
         """
         for child in self._children:
-           child.description = self._description
+           child.description = self._description   
 
     description = property(_get_description, _set_description)
+
+    def _get_thumbnail_explicit_recursive(self):
+        """
+        Returns true is item or any of its children is recursive
+        """
+        if self.thumbnail_explicit:
+            return True
+
+        for child in self._children:
+            if child.thumbnail_explicit:
+               return True
+
+        return False
+
+    def _propagate_thumbnail_to_children(self):
+        """
+        propagate thumbnail to children
+        """
+        for child in self._children:
+           child.thumbnail = self.thumbnail
+           child.thumbnail_explicit = False
 
     def _get_thumbnail(self):
         """

--- a/python/tk_multi_publish2/processing/item.py
+++ b/python/tk_multi_publish2/processing/item.py
@@ -280,7 +280,7 @@ class Item(object):
 
     def _get_thumbnail_explicit_recursive(self):
         """
-        Returns true is item or any of its children is recursive
+        Returns true is item or any of its children is explicit
         """
         if self.thumbnail_explicit:
             return True

--- a/python/tk_multi_publish2/processing/item.py
+++ b/python/tk_multi_publish2/processing/item.py
@@ -286,7 +286,7 @@ class Item(object):
             return True
 
         for child in self._children:
-            if child.thumbnail_explicit:
+            if child._get_thumbnail_explicit_recursive():
                return True
 
         return False
@@ -298,6 +298,7 @@ class Item(object):
         for child in self._children:
            child.thumbnail = self.thumbnail
            child.thumbnail_explicit = False
+           child._propagate_thumbnail_to_children()
 
     def _get_thumbnail(self):
         """

--- a/python/tk_multi_publish2/thumbnail.py
+++ b/python/tk_multi_publish2/thumbnail.py
@@ -35,6 +35,10 @@ class Thumbnail(QtGui.QLabel):
         :param parent: The parent QWidget for this control
         """
         QtGui.QLabel.__init__(self, parent)
+
+        #_multiple_values allows to display indicator that the summary thumbnail is not applied to all items
+        self._multiple_values = False
+
         self._thumbnail = None
         self._enabled = True
         self._bundle = sgtk.platform.current_bundle()
@@ -42,7 +46,7 @@ class Thumbnail(QtGui.QLabel):
         self.setCursor(QtCore.Qt.PointingHandCursor)
         self._no_thumb_pixmap = QtGui.QPixmap(":/tk_multi_publish2/camera.png")
         self._do_screengrab.connect(self._on_screengrab)
-        self.set_thumbnail(self._no_thumb_pixmap)
+        self.set_thumbnail(self._no_thumb_pixmap)       
 
     def setEnabled(self, enabled):
         """
@@ -113,8 +117,30 @@ class Thumbnail(QtGui.QLabel):
             self._bundle.log_debug(
                 "Got screenshot %sx%s" % (pixmap.width(), pixmap.height())
             )
+            self._multiple_values = False
             self._set_screenshot_pixmap(pixmap)
             self.screen_grabbed.emit(pixmap)
+
+    def _set_multiple_values_indicator(self, is_multiple_values):
+        """
+        Specifies wether to show multiple values indicator
+        """
+        self._multiple_values = is_multiple_values
+
+    def paintEvent(self, paint_event):
+        """
+        Paint Event override
+        """
+        # paint thumbnail
+        QtGui.QLabel.paintEvent(self, paint_event)
+
+        # paint multiple values indicator
+        if self._multiple_values == True:
+            p = QtGui.QPainter(self)
+            p.setFont(QtGui.QFont("Arial", 22, QtGui.QFont.Bold))
+            pen = QtGui.QPen(QtGui.QColor("#FF0000"))
+            p.setPen(pen)
+            p.drawText(self.rect(),QtCore.Qt.AlignRight,"* ")
 
     def _set_screenshot_pixmap(self, pixmap):
         """

--- a/python/tk_multi_publish2/thumbnail.py
+++ b/python/tk_multi_publish2/thumbnail.py
@@ -135,10 +135,11 @@ class Thumbnail(QtGui.QLabel):
         if self._multiple_values == True:
             p = QtGui.QPainter(self)
             p.drawPixmap(0,0,self.width(),self.height(),self._no_thumb_pixmap,0,0,self._no_thumb_pixmap.width(),self._no_thumb_pixmap.height())
-            p.setFont(QtGui.QFont("Arial", 14, QtGui.QFont.Bold))
+            p.fillRect(0,0,self.width(),self.height(),QtGui.QColor(42,42,42,237))
+            p.setFont(QtGui.QFont("Arial", 15, QtGui.QFont.Bold))
             pen = QtGui.QPen(QtGui.QColor("#18A7E3"))
             p.setPen(pen)
-            p.drawText(self.rect(),QtCore.Qt.AlignTop | QtCore.Qt.AlignHCenter,"Multiple Values")
+            p.drawText(self.rect(), QtCore.Qt.AlignCenter,"Multiple Values")
 
         else:
            # paint thumbnail

--- a/python/tk_multi_publish2/thumbnail.py
+++ b/python/tk_multi_publish2/thumbnail.py
@@ -131,16 +131,18 @@ class Thumbnail(QtGui.QLabel):
         """
         Paint Event override
         """
-        # paint thumbnail
-        QtGui.QLabel.paintEvent(self, paint_event)
-
         # paint multiple values indicator
         if self._multiple_values == True:
             p = QtGui.QPainter(self)
-            p.setFont(QtGui.QFont("Arial", 22, QtGui.QFont.Bold))
-            pen = QtGui.QPen(QtGui.QColor("#FF0000"))
+            p.drawPixmap(0,0,self.width(),self.height(),self._no_thumb_pixmap,0,0,self._no_thumb_pixmap.width(),self._no_thumb_pixmap.height())
+            p.setFont(QtGui.QFont("Arial", 14, QtGui.QFont.Bold))
+            pen = QtGui.QPen(QtGui.QColor("#0307FF"))
             p.setPen(pen)
-            p.drawText(self.rect(),QtCore.Qt.AlignRight,"* ")
+            p.drawText(self.rect(),QtCore.Qt.AlignTop | QtCore.Qt.AlignHCenter,"Multiple Values")
+
+        else:
+           # paint thumbnail
+           QtGui.QLabel.paintEvent(self, paint_event)
 
     def _set_screenshot_pixmap(self, pixmap):
         """

--- a/python/tk_multi_publish2/thumbnail.py
+++ b/python/tk_multi_publish2/thumbnail.py
@@ -136,7 +136,7 @@ class Thumbnail(QtGui.QLabel):
             p = QtGui.QPainter(self)
             p.drawPixmap(0,0,self.width(),self.height(),self._no_thumb_pixmap,0,0,self._no_thumb_pixmap.width(),self._no_thumb_pixmap.height())
             p.setFont(QtGui.QFont("Arial", 14, QtGui.QFont.Bold))
-            pen = QtGui.QPen(QtGui.QColor("#0307FF"))
+            pen = QtGui.QPen(QtGui.QColor("#18A7E3"))
             p.setPen(pen)
             p.drawText(self.rect(),QtCore.Qt.AlignTop | QtCore.Qt.AlignHCenter,"Multiple Values")
 


### PR DESCRIPTION
Implemented thumbnail inheritance
Items with default thumbnails are able to have override thumbnails set by the user
Implemented the equivalent to “Multiple Values” for thumbnail at the summary level that lets somebody know that they’d be overriding set thumbnails when they use that feature