### PR TITLE
Changed absolute imports to relative.

### DIFF
--- a/python/tk_multi_publish2/__init__.py
+++ b/python/tk_multi_publish2/__init__.py
@@ -10,8 +10,8 @@
 
 import sgtk
 
-import base_hooks
-import util
+from . import base_hooks
+from . import util
 
 def show_dialog(app):
     """

--- a/python/tk_multi_publish2/base_hooks/__init__.py
+++ b/python/tk_multi_publish2/base_hooks/__init__.py
@@ -8,5 +8,5 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-from collector import CollectorPlugin
-from publish_plugin import PublishPlugin
+from .collector import CollectorPlugin
+from .publish_plugin import PublishPlugin


### PR DESCRIPTION
Noticed some absolute imports in the publisher that are potentially dangerous - especially the `base_hooks` import is likely to overlap with other apps using `base_hooks`. @josh-t if you could take a quick look and check that this makes sense that would be great! thx!