### PR TITLE
#45629 thumbnail inheritance for items added to publish after setting summary thumbnail

### DIFF
--- a/python/tk_multi_publish2/processing/item.py
+++ b/python/tk_multi_publish2/processing/item.py
@@ -58,7 +58,7 @@ class Item(object):
         self._thumbnail_enabled = True
         self._allows_context_change = True
         # the following var indicates that the current thumbnail overrides the summary one
-        self._thumbnail_explicit = False
+        self._thumbnail_explicit = True
 
     def __repr__(self):
         """


### PR DESCRIPTION
Items that are added to publish after setting the summary thumbnail should not inherit summary thumbnail that was already set before. They should inherit it when the summary thumbnail is set after the items have been added.