### PR TITLE
46405 add setting to disable content load2

### DIFF
--- a/python/tk_multi_publish2/dialog.py
+++ b/python/tk_multi_publish2/dialog.py
@@ -732,7 +732,7 @@ class AppDialog(QtGui.QWidget):
 
         # Short circuiting method disabling actual action performed on dropping to the target.
         if not self.manual_load_enabled:
-            self._progress_handler.logger.info("Drag & drop disabled.")
+            self._progress_handler.logger.error("Drag & drop disabled.")
             return
 
         # add files and rebuild tree
@@ -1278,7 +1278,7 @@ class AppDialog(QtGui.QWidget):
         self.ui.progress_bar.hide()
         self.ui.close.show()
 
-        self._progress_handler.logger.info("Drag & drop disabled.")
+        self._progress_handler.logger.error("Drag & drop disabled.")
 
         self.ui.main_stack.setCurrentIndex(self.PUBLISH_SCREEN)
         self._overlay.show_no_items_error()

--- a/python/tk_multi_publish2/dialog.py
+++ b/python/tk_multi_publish2/dialog.py
@@ -1278,6 +1278,8 @@ class AppDialog(QtGui.QWidget):
         self.ui.progress_bar.hide()
         self.ui.close.show()
 
+        self._progress_handler.logger.info("Drag & drop disabled.")
+
         self.ui.main_stack.setCurrentIndex(self.PUBLISH_SCREEN)
         self._overlay.show_no_items_error()
 

--- a/python/tk_multi_publish2/dialog.py
+++ b/python/tk_multi_publish2/dialog.py
@@ -113,8 +113,9 @@ class AppDialog(QtGui.QWidget):
         self.ui.close.clicked.connect(self.close)
         self.ui.close.hide()
 
-        # overlays
+        # overlay
         self._overlay = SummaryOverlay(self.ui.main_frame)
+        self._overlay.publish_again_clicked.connect(self._publish_again_clicked)
 
         # settings
         self.ui.items_tree.status_clicked.connect(self._on_publish_status_clicked)

--- a/python/tk_multi_publish2/dialog.py
+++ b/python/tk_multi_publish2/dialog.py
@@ -1275,6 +1275,7 @@ class AppDialog(QtGui.QWidget):
         self.ui.validate.hide()
         self.ui.publish.hide()
         self.ui.button_container.hide()
+        self.ui.progress_bar.hide()
         self.ui.close.show()
 
         self.ui.main_stack.setCurrentIndex(self.PUBLISH_SCREEN)

--- a/python/tk_multi_publish2/summary_overlay.py
+++ b/python/tk_multi_publish2/summary_overlay.py
@@ -65,7 +65,7 @@ class SummaryOverlay(QtGui.QWidget):
         # Usage of label's own word wrap displays the message below on 3 lines.
         # NOTE: Can't manually break line when using <p></p>
         self.ui.label.setText("Could not find any\nitems to publish.")
-        self.ui.info.hide()
+        self.ui.info.setText("For more details, <b><u>click here</u></b>.")
         self.ui.publish_again.hide()
         self.show()
 


### PR DESCRIPTION
Adresses some minor issues + 1 regression found by QA:
- Hide progress bar in the no items error overlay
- Fix publish again button broken in previous commit
- Add 'More details' label in the no item error overly
- Add unconditionality the "Drag & drop disabled." to message log queue.

![screen shot 2018-02-05 at 6 03 10 pm---2](https://user-images.githubusercontent.com/5750337/35834038-cb8c9090-0aa1-11e8-9570-3377bf89bdfe.png)
