### PR TITLE
#46342 Adds publish file plugin instance publish properties

### DIFF
--- a/hooks/publish_file.py
+++ b/hooks/publish_file.py
@@ -80,36 +80,6 @@ class BasicFilePublishPlugin(HookBaseClass):
             registering the publish. If the item's parent has been published,
             it's path will be appended to this list.
 
-    It is important to consider when to set a value via ``item.properties`` and
-    when to use ``item.local_properties``. Setting the values on
-    ``item.properties`` is a way to globally share information between publish
-    plugins. Values set via ``item.local_properties`` will only be applied
-    during the execution of the current plugin (similar to python's
-    ``threading.local`` storage).
-
-    A common scenario to consider is when you have multiple publish plugins
-    acting on the same item. You may, for example, want the ``publish_name`` and
-    ``publish_version`` to be shared by each plugin, while setting the remaining
-    properties on each plugin instance since they will be specific to that
-    plugin's output.
-
-    Example::
-
-        # set shared properties on the item (potentially in the collector or
-        # the first publish plugin). these values will be available to all
-        # publish plugins attached to the item.
-        item.properties.publish_name = "Gorilla"
-        item.properties.publish_version = "0003"
-
-        # set specific properties in subclasses of the base file publish (this
-        # class). first publish plugin...
-        item.local_properties.publish_template = "asset_fbx_template"
-        item.local_properties.publish_type = "FBX File"
-
-        # in another publish plugin...
-        item.local_properties.publish_template = "asset_abc_template"
-        item.local_properties.publish_type = "Alembic Cache"
-
     NOTE: accessing these ``publish_*`` values on the item does not necessarily
     return the value used during publish execution. Use the corresponding
     ``get_publish_*`` methods which include fallback logic when no property is
@@ -243,7 +213,7 @@ class BasicFilePublishPlugin(HookBaseClass):
         return ["file.*"]
 
     ############################################################################
-    # standard publish plugin mehtods
+    # standard publish plugin methods
 
     def accept(self, settings, item):
         """
@@ -271,7 +241,7 @@ class BasicFilePublishPlugin(HookBaseClass):
         :returns: dictionary with boolean keys accepted, required and enabled
         """
 
-        path = item.properties["path"]
+        path = item.properties.path
 
         # log the accepted file and display a button to reveal it in the fs
         self.logger.info(
@@ -394,8 +364,7 @@ class BasicFilePublishPlugin(HookBaseClass):
         # if the parent item has a publish path, include it in the list of
         # dependencies
         if "sg_publish_path" in item.parent.properties:
-            publish_dependencies.append(
-                item.parent.properties["sg_publish_path"])
+            publish_dependencies.append(item.parent.properties.sg_publish_path)
 
         # handle copying of work to publish if templates are in play
         self._copy_work_to_publish(settings, item)
@@ -428,7 +397,7 @@ class BasicFilePublishPlugin(HookBaseClass):
 
         # create the publish and stash it in the item properties for other
         # plugins to use.
-        item.properties["sg_publish_data"] = sgtk.util.register_publish(
+        item.properties.sg_publish_data = sgtk.util.register_publish(
             **publish_data)
         self.logger.info("Publish registered!")
 
@@ -447,7 +416,7 @@ class BasicFilePublishPlugin(HookBaseClass):
         publisher = self.parent
 
         # get the data for the publish that was just created in SG
-        publish_data = item.properties["sg_publish_data"]
+        publish_data = item.properties.sg_publish_data
 
         # ensure conflicting publishes have their status cleared
         publisher.util.clear_status_for_conflicting_publishes(
@@ -456,7 +425,7 @@ class BasicFilePublishPlugin(HookBaseClass):
         self.logger.info(
             "Cleared the status of all previous, conflicting publishes")
 
-        path = item.properties["path"]
+        path = item.properties.path
         self.logger.info(
             "Publish created for file: %s" % (path,),
             extra={
@@ -500,7 +469,7 @@ class BasicFilePublishPlugin(HookBaseClass):
 
         # fall back to the path info hook logic
         publisher = self.parent
-        path = item.properties["path"]
+        path = item.properties.path
 
         # get the publish path components
         path_info = publisher.util.get_file_path_components(path)
@@ -553,7 +522,7 @@ class BasicFilePublishPlugin(HookBaseClass):
             return publish_path
 
         # fall back to template/path logic
-        path = item.properties["path"]
+        path = item.properties.path
 
         work_template = item.properties.get("work_template")
         publish_template = self.get_publish_template(settings, item)
@@ -609,7 +578,7 @@ class BasicFilePublishPlugin(HookBaseClass):
 
         # fall back to the template/path_info logic
         publisher = self.parent
-        path = item.properties["path"]
+        path = item.properties.path
 
         work_template = item.properties.get("work_template")
         work_fields = None
@@ -656,11 +625,11 @@ class BasicFilePublishPlugin(HookBaseClass):
 
         # fall back to the path_info logic
         publisher = self.parent
-        path = item.properties["path"]
+        path = item.properties.path
 
         if "sequence_paths" in item.properties:
             # generate the name from one of the actual files in the sequence
-            name_path = item.properties["sequence_paths"][0]
+            name_path = item.properties.sequence_paths[0]
             is_sequence = True
         else:
             name_path = path
@@ -743,7 +712,7 @@ class BasicFilePublishPlugin(HookBaseClass):
         # ---- get a list of files to be copied
 
         # by default, the path that was collected for publishing
-        work_files = [item.properties["path"]]
+        work_files = [item.properties.path]
 
         # if this is a sequence, get the attached files
         if "sequence_paths" in item.properties:
@@ -751,7 +720,7 @@ class BasicFilePublishPlugin(HookBaseClass):
             if not work_files:
                 self.logger.warning(
                     "Sequence publish without a list of files. Publishing "
-                    "the sequence path in place: %s" % (item.properties["path"])
+                    "the sequence path in place: %s" % (item.properties.path,)
                 )
                 return
 

--- a/hooks/publish_file.py
+++ b/hooks/publish_file.py
@@ -51,7 +51,7 @@ class BasicFilePublishPlugin(HookBaseClass):
             version to be registered in Shotgun.
 
     The following properties can also be set by a subclass of this plugin via
-    ``item.properties`` or ``item.local_properties``.
+    :meth:`Item.properties` or :meth:`Item.local_properties`.
 
         publish_template - If set, used to determine where "path" should be
             copied prior to publishing. If not specified, "path" will be
@@ -448,8 +448,7 @@ class BasicFilePublishPlugin(HookBaseClass):
             None if no template could be identified.
         """
 
-        return item.local_properties.get("publish_template") or \
-            item.properties.get("publish_template")
+        return item.get_property("publish_template")
 
     def get_publish_type(self, settings, item):
         """
@@ -462,8 +461,7 @@ class BasicFilePublishPlugin(HookBaseClass):
         """
 
         # publish type explicitly set or defined on the item
-        publish_type = item.local_properties.get("publish_type") or \
-                item.properties.get("publish_type")
+        publish_type = item.get_property("publish_type")
         if publish_type:
             return publish_type
 
@@ -516,8 +514,7 @@ class BasicFilePublishPlugin(HookBaseClass):
         """
 
         # publish type explicitly set or defined on the item
-        publish_path = item.local_properties.get("publish_path") or \
-            item.properties.get("publish_path")
+        publish_path = item.get_property("publish_path")
         if publish_path:
             return publish_path
 
@@ -571,8 +568,7 @@ class BasicFilePublishPlugin(HookBaseClass):
         """
 
         # publish version explicitly set or defined on the item
-        publish_version = item.local_properties.get("publish_version") or \
-            item.properties.get("publish_version")
+        publish_version = item.get_property("publish_version")
         if publish_version:
             return publish_version
 
@@ -618,8 +614,7 @@ class BasicFilePublishPlugin(HookBaseClass):
         """
 
         # publish name explicitly set or defined on the item
-        publish_name = item.local_properties.get("publish_name") or \
-            item.properties.get("publish_name")
+        publish_name = item.get_property("publish_name")
         if publish_name:
             return publish_name
 

--- a/hooks/publish_file.py
+++ b/hooks/publish_file.py
@@ -28,74 +28,104 @@ class BasicFilePublishPlugin(HookBaseClass):
     validating and registering publishes with Shotgun.
 
     Once attached to a publish item, the plugin will key off of properties that
-    are set on the item. These properties can be set via the collector or
-    by subclasses prior to calling methods on this class.
+    drive how the item is published.
 
-    The only property that is required for the plugin to operate is the ``path``
-    property. All of the properties understood by the plugin are documented
-    below::
+    The ``path`` property, set on the item, is the only required property as it
+    informs the plugin where the file to publish lives on disk.
 
-        Path properties
-        -------------
+    The following properties can be set on the item via the collector or by
+    subclasses prior to calling methods on the base class::
 
-        path - The path to the file to be published.
+        ``sequence_paths`` - If set in the item properties dictionary, implies
+            the "path" property represents a sequence of files (typically using
+            a frame identifier such as %04d). This property should be a list of
+            files on disk matching the "path". If the ``work_template`` property
+            is set, and corresponds to the listed frames, fields will be
+            extracted and applied to the publish_template (if set) and copied to
+            that publish location.
 
-        sequence_paths - If set, implies the "path" property represents a
-            sequence of files (typically using a frame identifier such as %04d).
-            This property should be a list of files on disk matching the "path".
-            If a work template is provided, and corresponds to the listed
-            frames, fields will be extracted and applied to the publish template
-            (if set) and copied to that publish location.
+        ``work_template`` - If set in the item properties dictionary, this
+            value is used to validate ``path`` and extract fields for further
+            processing and contextual discovery. For example, if configured and
+            a version key can be extracted, it will be used as the publish
+            version to be registered in Shotgun.
 
-        Template properties
-        -------------------
+    The following properties are typically set by a subclass of this plugin via
+    the ``item.properties`` dictionary or by using the plugin instance's
+    properties of the same name::
 
-        work_template - If set in the item properties dictionary, is used
-            to validate "path" and extract fields for further processing and
-            contextual discovery. For example, if configured and a version key
-            can be extracted, it will be used as the publish version to be
-            registered in Shotgun.
+        - ``publish_template``
+        - ``publish_type``
+        - ``publish_path``
+        - ``publish_name``
+        - ``publish_version``
+        - ``publish_dependencies``
 
-        publish_template - If set in the item properties dictionary, used to
-            determine where "path" should be copied prior to publishing. If
-            not specified, "path" will be published in place.
+    See the documentation for these properties below.
 
-        Publish properties
-        ------------------
+    It is important to consider when to set a value via ``item.properties`` and
+    when to use the plugin instance properties. Setting these values on the item
+    is a way to share information between publish plugins. Values set on the
+    plugin instance will only be applied during the execution of that plugin.
 
-        publish_type - If set in the item properties dictionary, will be
-            supplied to SG as the publish type when registering "path" as a new
-            publish. If not set, will be determined via the plugin's "File Type"
-            setting.
+    A common scenario to consider is when you have multiple publish plugins
+    acting on the same item. You may, for example, want the ``publish_name`` and
+    ``publish_version`` to be shared by each plugin, while setting the remaining
+    properties on each plugin instance since they will be specific to that
+    plugin's output.
 
-        publish_path - If set in the item properties dictionary, will be
-            supplied to SG as the publish path when registering the new publish.
-            If not set, will be determined by the "published_file" property if
-            available, falling back to publishing "path" in place.
+    Example::
 
-        publish_name - If set in the item properties dictionary, will be
-            supplied to SG as the publish name when registering the new publish.
-            If not available, will be determined by the "work_template"
-            property if available, falling back to the ``path_info`` hook
-            logic.
+        # set shared properties on the item (potentially in the first publish
+        # plugin). these values will be available to all publish plugins
+        # attached to the item.
+        item.properties["publish_name"] = "Gorilla"
+        item.properties["publish_version"] = "0003"
 
-        publish_version - If set in the item properties dictionary, will be
-            supplied to SG as the publish version when registering the new
-            publish. If not available, will be determined by the
-            "work_template" property if available, falling back to the
-            ``path_info`` hook logic.
+        # set specific properties in subclasses of the base file publish (this
+        # class). first publish plugin...
+        self.publish_template = "asset_fbx_template"
+        self.publish_type = "FBX File"
 
-        publish_dependencies - A list of files to include as dependencies when
-            registering the publish. If the item's parent has been published,
-            it's path will be appended to this list.
+        # in another publish plugin...
+        self.publish_template = "asset_abc_template"
+        self.publish_type = "Alembic Cache"
 
-    This plugin will also set the properties on the item which may be useful for
-    child items.
+    NOTE: properties values set on the plugin instance will override similar
+    values defined on the item. Additional fallback logic is used if neither is
+    set. For example, if a ``work_template`` is used, the publish version and
+    name might be extracted from the template fields.
 
-        sg_publish_data - The dictionary of publish information returned from
-            the tk-core register_publish method.
+    This plugin will also set an ``sg_publish_data`` property on the item during
+    the ``publish`` method which may be useful for child items.
 
+        ``sg_publish_data`` - The dictionary of publish information returned
+            from the tk-core register_publish method.
+
+    NOTE: If you have multiple plugins acting on the same item, and you need to
+    access or operate on the publish data, you can extract the
+    ``sg_publish_data`` from the item after calling the base class ``publish``
+    method in your plugin subclass.
     """
+
+    def __init__(self, parent):
+        """
+        Initialize the hook instance.
+        """
+
+        # initialize the base class
+        super(BasicFilePublishPlugin, self).__init__(parent)
+
+        # set some instance members
+        self._publish_template = None
+        self._publish_type = None
+        self._publish_path = None
+        self._publish_name = None
+        self._publish_version = None
+        self._publish_dependencies = None
+
+    ############################################################################
+    # standard publish plugin properties
 
     @property
     def icon(self):
@@ -208,6 +238,9 @@ class BasicFilePublishPlugin(HookBaseClass):
         """
         return ["file.*"]
 
+    ############################################################################
+    # standard publish plugin mehtods
+
     def accept(self, settings, item):
         """
         Method called by the publisher to determine if an item is of any
@@ -272,11 +305,8 @@ class BasicFilePublishPlugin(HookBaseClass):
         # base class plugin. They may have more information than is available
         # here such as custom type or template settings.
 
-        publish_path = item.properties.get("publish_path") or \
-            self._get_publish_path(settings, item)
-
-        publish_name = item.properties.get("publish_name") or \
-            self._get_publish_name(settings, item)
+        publish_path = self.get_publish_path(settings, item)
+        publish_name = self.get_publish_name(settings, item)
 
         # ---- check for conflicting publishes of this path with a status
 
@@ -295,8 +325,9 @@ class BasicFilePublishPlugin(HookBaseClass):
             self.logger.debug(
                 "Conflicting publishes: %s" % (pprint.pformat(publishes),))
 
-            if ("work_template" in item.properties or
-                "publish_template" in item.properties):
+            publish_template = self.get_publish_template(settings, item)
+
+            if "work_template" in item.properties or publish_template:
 
                 # templates are in play and there is already a publish in SG
                 # for this file path. We will raise here to prevent this from
@@ -350,30 +381,24 @@ class BasicFilePublishPlugin(HookBaseClass):
         # base class plugin. They may have more information than is available
         # here such as custom type or template settings.
 
-        publish_type = item.properties.get("publish_type") or \
-            self._get_publish_type(settings, item)
-
-        publish_name = item.properties.get("publish_name") or \
-            self._get_publish_name(settings, item)
-
-        publish_version = item.properties.get("publish_version") or \
-            self._get_publish_version(settings, item)
-
-        publish_path = item.properties.get("publish_path") or \
-            self._get_publish_path(settings, item)
+        publish_type = self.get_publish_type(settings, item)
+        publish_name = self.get_publish_name(settings, item)
+        publish_version = self.get_publish_version(settings, item)
+        publish_path = self.get_publish_path(settings, item)
+        publish_dependencies = self.get_publish_dependencies(settings, item)
 
         # if the parent item has a publish path, include it in the list of
         # dependencies
-        dependency_paths = item.properties.get("publish_dependencies", [])
         if "sg_publish_path" in item.parent.properties:
-            dependency_paths.append(item.parent.properties["sg_publish_path"])
+            publish_dependencies.append(
+                item.parent.properties["sg_publish_path"])
 
         # handle copying of work to publish if templates are in play
         self._copy_work_to_publish(settings, item)
 
         # arguments for publish registration
         self.logger.info("Registering publish...")
-        publish_data= {
+        publish_data = {
             "tk": publisher.sgtk,
             "context": item.context,
             "comment": item.description,
@@ -382,7 +407,7 @@ class BasicFilePublishPlugin(HookBaseClass):
             "version_number": publish_version,
             "thumbnail_path": item.get_thumbnail_as_path(),
             "published_file_type": publish_type,
-            "dependency_paths": dependency_paths
+            "dependency_paths": publish_dependencies
         }
 
         # log the publish data for debugging
@@ -440,6 +465,287 @@ class BasicFilePublishPlugin(HookBaseClass):
         )
 
     ############################################################################
+    # publish properties
+
+    def _set_publish_template(self, template):
+        """
+        Set the publish_template for this plugin to use.
+        :param template: A template object
+        """
+        self._publish_template = template
+
+    publish_template = property(None, _set_publish_template)
+
+    def _set_publish_type(self, publish_type):
+        """
+        Set the publish_type for this plugin to use.
+        :param publish_type: A string representing the publish type to store in
+            Shotgun.
+        """
+        self._publish_type = publish_type
+
+    publish_type = property(None, _set_publish_type)
+
+    def _set_publish_path(self, path):
+        """
+        Sets the publish_path for this plugin to use.
+        :param path: A string file path
+        """
+        self._publish_path = path
+
+    publish_path = property(None, _set_publish_path)
+
+    def _set_publish_name(self, name):
+        """
+        Sets the publish_name for this plugin to use.
+        :param name: The publish name to use
+        """
+        self._publish_name = name
+
+    publish_name = property(None, _set_publish_name)
+
+    def _set_publish_version(self, version):
+        """
+        Sets the publish_version for this plugin to use
+        :param version: The version number to publish to.
+        """
+        self._publish_version = version
+
+    publish_version = property(None, _set_publish_version)
+
+    def _set_publish_dependencies(self, dependencies):
+        """
+        Sets the publish dependencies.
+        :param dependencies: A list of file paths that this publish is
+            dependent on.
+        """
+        self._publish_dependencies = dependencies
+
+    publish_dependencies = property(None, _set_publish_dependencies)
+
+    # The properties above define the "setter", `self.publish_X = value`
+    # interface for explicitly setting the publish_* values on the plugin
+    # instance. The "getter" methods below are defined as methods since they
+    # require the settings and item as context for the full evaluation of the
+    # value. Most of these can be called without explicitly setting a value on
+    # the plugin instance due to their fallback logic.
+
+    def get_publish_template(self, settings, item):
+        """
+        Get a publish template for the supplied settings and item.
+
+        :param settings: This plugin instance's configured settings
+        :param item: The item to determine the publish template for
+
+        :return: A template representing the publish path of the item or
+            None if no template could be identified.
+        """
+
+        return self._publish_template or item.properties.get("publish_template")
+
+    def get_publish_type(self, settings, item):
+        """
+        Get a publish type for the supplied settings and item.
+
+        :param settings: This plugin instance's configured settings
+        :param item: The item to determine the publish type for
+
+        :return: A publish type or None if one could not be found.
+        """
+
+        # publish type explicitly set or defined on the item
+        publish_type = self._publish_type or item.properties.get("publish_type")
+        if publish_type:
+            return publish_type
+
+        # fall back to the path info hook logic
+        publisher = self.parent
+        path = item.properties["path"]
+
+        # get the publish path components
+        path_info = publisher.util.get_file_path_components(path)
+
+        # determine the publish type
+        extension = path_info["extension"]
+
+        # ensure lowercase and no dot
+        if extension:
+            extension = extension.lstrip(".").lower()
+
+            for type_def in settings["File Types"].value:
+
+                publish_type = type_def[0]
+                file_extensions = type_def[1:]
+
+                if extension in file_extensions:
+                    # found a matching type in settings. use it!
+                    return publish_type
+
+        # --- no pre-defined publish type found...
+
+        if extension:
+            # publish type is based on extension
+            publish_type = "%s File" % extension.capitalize()
+        else:
+            # no extension, assume it is a folder
+            publish_type = "Folder"
+
+        return publish_type
+
+    def get_publish_path(self, settings, item):
+        """
+        Get a publish path for the supplied settings and item.
+
+        :param settings: This plugin instance's configured settings
+        :param item: The item to determine the publish path for
+
+        :return: A string representing the output path to supply when
+            registering a publish for the supplied item
+
+        Extracts the publish path via the configured work and publish templates
+        if possible.
+        """
+
+        # publish type explicitly set or defined on the item
+        publish_path = self._publish_path or item.properties.get("publish_path")
+        if publish_path:
+            return publish_path
+
+        # fall back to template/path logic
+        path = item.properties["path"]
+
+        work_template = item.properties.get("work_template")
+        publish_template = self.get_publish_template(settings, item)
+
+        work_fields = []
+        publish_path = None
+
+        # We need both work and publish template to be defined for template
+        # support to be enabled.
+        if work_template and publish_template:
+            if work_template.validate(path):
+                work_fields = work_template.get_fields(path)
+
+            missing_keys = publish_template.missing_keys(work_fields)
+
+            if missing_keys:
+                self.logger.warning(
+                    "Not enough keys to apply work fields (%s) to "
+                    "publish template (%s)" % (work_fields, publish_template))
+            else:
+                publish_path = publish_template.apply_fields(work_fields)
+                self.logger.debug(
+                    "Used publish template to determine the publish path: %s" %
+                    (publish_path,)
+                )
+        else:
+            self.logger.debug("publish_template: %s" % publish_template)
+            self.logger.debug("work_template: %s" % work_template)
+
+        if not publish_path:
+            publish_path = path
+            self.logger.debug(
+                "Could not validate a publish template. Publishing in place.")
+
+        return publish_path
+
+    def get_publish_version(self, settings, item):
+        """
+        Get the publish version for the supplied settings and item.
+
+        :param settings: This plugin instance's configured settings
+        :param item: The item to determine the publish version for
+
+        Extracts the publish version via the configured work template if
+        possible. Will fall back to using the path info hook.
+        """
+
+        # publish version explicitly set or defined on the item
+        publish_version = self._publish_version or \
+            item.properties.get("publish_version")
+        if publish_version:
+            return publish_version
+
+        # fall back to the template/path_info logic
+        publisher = self.parent
+        path = item.properties["path"]
+
+        work_template = item.properties.get("work_template")
+        work_fields = None
+        publish_version = None
+
+        if work_template:
+            if work_template.validate(path):
+                self.logger.debug(
+                    "Work file template configured and matches file.")
+                work_fields = work_template.get_fields(path)
+
+        if work_fields:
+            # if version number is one of the fields, use it to populate the
+            # publish information
+            if "version" in work_fields:
+                publish_version = work_fields.get("version")
+                self.logger.debug(
+                    "Retrieved version number via work file template.")
+
+        else:
+            self.logger.debug(
+                "Using path info hook to determine publish version.")
+            publish_version = publisher.util.get_version_number(path)
+            if publish_version is None:
+                publish_version = 1
+
+        return publish_version
+
+    def get_publish_name(self, settings, item):
+        """
+        Get the publish name for the supplied settings and item.
+
+        :param settings: This plugin instance's configured settings
+        :param item: The item to determine the publish name for
+
+        Uses the path info hook to retrieve the publish name.
+        """
+
+        # publish name explicitly set or defined on the item
+        publish_name = self._publish_name or item.properties.get("publish_name")
+        if publish_name:
+            return publish_name
+
+        # fall back to the path_info logic
+        publisher = self.parent
+        path = item.properties["path"]
+
+        if "sequence_paths" in item.properties:
+            # generate the name from one of the actual files in the sequence
+            name_path = item.properties["sequence_paths"][0]
+            is_sequence = True
+        else:
+            name_path = path
+            is_sequence = False
+
+        return publisher.util.get_publish_name(
+            name_path,
+            sequence=is_sequence
+        )
+
+    def get_publish_dependencies(self, settings, item):
+        """
+        Get publish dependencies for the supplied settings and item.
+
+        :param settings: This plugin instance's configured settings
+        :param item: The item to determine the publish template for
+
+        :return: A list of file paths representing the dependencies to store in
+            SG for this publish
+        """
+
+        if self._publish_dependencies is not None:
+            return self._publish_dependencies
+
+        return item.properties.get("publish_dependencies", [])
+
+    ############################################################################
     # protected methods
 
     def _copy_work_to_publish(self, settings, item):
@@ -474,7 +780,7 @@ class BasicFilePublishPlugin(HookBaseClass):
             )
             return
 
-        publish_template = item.properties.get("publish_template")
+        publish_template = self.get_publish_template(settings, item)
         if not publish_template:
             self.logger.debug(
                 "No publish template set on the item. "
@@ -536,165 +842,6 @@ class BasicFilePublishPlugin(HookBaseClass):
                 "Copied work file '%s' to publish file '%s'." %
                 (work_file, publish_file)
             )
-
-    def _get_publish_type(self, settings, item):
-        """
-        Get a publish type for the supplied settings and item.
-
-        :param settings: The publish settings defining the publish types
-        :param item: The item to determine the publish type for
-
-        :return: A publish type or None if one could not be found.
-        """
-
-        publisher = self.parent
-        path = item.properties["path"]
-
-        # get the publish path components
-        path_info = publisher.util.get_file_path_components(path)
-
-        # determine the publish type
-        extension = path_info["extension"]
-
-        # ensure lowercase and no dot
-        if extension:
-            extension = extension.lstrip(".").lower()
-
-            for type_def in settings["File Types"].value:
-
-                publish_type = type_def[0]
-                file_extensions = type_def[1:]
-
-                if extension in file_extensions:
-                    # found a matching type in settings. use it!
-                    return publish_type
-
-        # --- no pre-defined publish type found...
-
-        if extension:
-            # publish type is based on extension
-            publish_type = "%s File" % extension.capitalize()
-        else:
-            # no extension, assume it is a folder
-            publish_type = "Folder"
-
-        return publish_type
-
-    def _get_publish_path(self, settings, item):
-        """
-        Get a publish path for the supplied settings and item.
-
-        :param settings: The publish settings defining the publish types
-        :param item: The item to determine the publish type for
-
-        :return: A string representing the output path to supply when
-            registering a publish for the supplied item
-
-        Extracts the publish path via the configured work and publish templates
-        if possible.
-        """
-
-        path = item.properties["path"]
-
-        work_template = item.properties.get("work_template")
-        publish_template = item.properties.get("publish_template")
-
-        work_fields = []
-        publish_path = None
-
-        # We need both work and publish template to be defined for template support to be enabled.
-        if work_template and publish_template:
-            if work_template.validate(path):
-                work_fields = work_template.get_fields(path)
-
-            missing_keys = publish_template.missing_keys(work_fields)
-
-            if missing_keys:
-                self.logger.warning(
-                    "Not enough keys to apply work fields (%s) to "
-                    "publish template (%s)" % (work_fields, publish_template))
-            else:
-                publish_path = publish_template.apply_fields(work_fields)
-                self.logger.debug(
-                    "Used publish template to determine the publish path: %s" %
-                    (publish_path,)
-                )
-        else:
-            self.logger.debug("publish_template: %s" % publish_template)
-            self.logger.debug("work_template: %s" % work_template)
-
-        if not publish_path:
-            publish_path = path
-            self.logger.debug(
-                "Could not validate a publish template. Publishing in place.")
-
-        return publish_path
-
-    def _get_publish_version(self, settings, item):
-        """
-        Get the publish version for the supplied settings and item.
-
-        :param settings: The publish settings defining the publish types
-        :param item: The item to determine the publish version for
-
-        Extracts the publish version via the configured work template if
-        possible. Will fall back to using the path info hook.
-        """
-
-        publisher = self.parent
-        path = item.properties["path"]
-
-        work_template = item.properties.get("work_template")
-        work_fields = None
-        publish_version = None
-
-        if work_template:
-            if work_template.validate(path):
-                self.logger.debug(
-                    "Work file template configured and matches file.")
-                work_fields = work_template.get_fields(path)
-
-        if work_fields:
-            # if version number is one of the fields, use it to populate the
-            # publish information
-            if "version" in work_fields:
-                publish_version = work_fields.get("version")
-                self.logger.debug(
-                    "Retrieved version number via work file template.")
-
-        else:
-            self.logger.debug("Using path info hook to determine publish version.")
-            publish_version = publisher.util.get_version_number(path)
-            if publish_version is None:
-                publish_version = 1
-
-        return publish_version
-
-    def _get_publish_name(self, settings, item):
-        """
-        Get the publish name for the supplied settings and item.
-
-        :param settings: The publish settings defining the publish types
-        :param item: The item to determine the publish version for
-
-        Uses the path info hook to retrieve the publish name.
-        """
-
-        publisher = self.parent
-        path = item.properties["path"]
-
-        if "sequence_paths" in item.properties:
-            # generate the name from one of the actual files in the sequence
-            name_path = item.properties["sequence_paths"][0]
-            is_sequence = True
-        else:
-            name_path = path
-            is_sequence = False
-
-        return publisher.util.get_publish_name(
-            name_path,
-            sequence=is_sequence
-        )
 
     def _get_next_version_info(self, path, item):
         """

--- a/python/tk_multi_publish2/processing/item.py
+++ b/python/tk_multi_publish2/processing/item.py
@@ -259,16 +259,16 @@ class Item(object):
         """
 
         # try to determine the current publish plugin
-        class_instance = inspect.stack()[1][0].f_locals.get("self")
-        if not class_instance or not isinstance(class_instance, PublishPlugin):
+        calling_object = inspect.stack()[1][0].f_locals.get("self")
+        if not calling_object or not isinstance(calling_object, PublishPlugin):
             raise AttributeError(
                 "Could not determine the current publish plugin when accessing "
                 "an item's local properties. Item: %s" % (self,))
 
-        if class_instance not in self._local_properties:
-            self._local_properties[class_instance] = _ItemProperties()
+        if calling_object not in self._local_properties:
+            self._local_properties[calling_object] = _ItemProperties()
 
-        return self._local_properties[class_instance]
+        return self._local_properties[calling_object]
 
     @property
     def tasks(self):

--- a/python/tk_multi_publish2/processing/item.py
+++ b/python/tk_multi_publish2/processing/item.py
@@ -225,7 +225,37 @@ class Item(object):
 
         Attempts to access this property outside of a publish plugin will raise
         an ``AttributeError``.
-        :return:
+
+        It is important to consider when to set a value via ``item.properties``
+        and when to use ``item.local_properties``. Setting the values on
+        ``item.properties`` is a way to globally share information between
+        publish plugins. Values set via ``item.local_properties`` will only be
+        applied during the execution of the current plugin (similar to python's
+        ``threading.local`` storage).
+
+        A common scenario to consider is when you have multiple publish plugins
+        acting on the same item. You may, for example, want the ``publish_name``
+        and ``publish_version`` to be shared by each plugin, while setting the
+        remaining properties on each plugin instance since they will be specific
+        to that plugin's output.
+
+        Example::
+
+            # set shared properties on the item (potentially in the collector or
+            # the first publish plugin). these values will be available to all
+            # publish plugins attached to the item.
+            item.properties.publish_name = "Gorilla"
+            item.properties.publish_version = "0003"
+
+            # set specific properties in subclasses of the base file publish (this
+            # class). first publish plugin...
+            item.local_properties.publish_template = "asset_fbx_template"
+            item.local_properties.publish_type = "FBX File"
+
+            # in another publish plugin...
+            item.local_properties.publish_template = "asset_abc_template"
+            item.local_properties.publish_type = "Alembic Cache"
+
         """
 
         # try to determine the current publish plugin

--- a/python/tk_multi_publish2/processing/item.py
+++ b/python/tk_multi_publish2/processing/item.py
@@ -208,6 +208,9 @@ class Item(object):
 
         For properties that are local to the current plugin, see
         ``local_properties``.
+
+        This property can also be used to store data on an items that may then
+        be accessed by plugins attached to the item's children.
         """
         return self._global_properties
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -3,6 +3,7 @@ About the test app
 To launch the test app, you need to make sure the following repos are
 adjacent to the tk-multi-publish2 repo.
 
+- tk-core (for bootstrapping)
 - tk-frameworks-qtwidgets
 - tk-frameworks-shotgunutils
 

--- a/tests/fixtures/config/env/test.yml
+++ b/tests/fixtures/config/env/test.yml
@@ -49,6 +49,15 @@ engines:
               number: 0
               boolean: false
               supports_multi_edit: false
+          - name: Property Test 1
+            hook: "{self}/publish_file.py:{config}/test_properties_plugin_1.py"
+            settings: {}
+          - name: Property Test 2
+            hook: "{self}/publish_file.py:{config}/test_properties_plugin_2.py"
+            settings: {}
+          - name: Property Test 3
+            hook: "{self}/publish_file.py:{config}/test_properties_plugin_3.py"
+            settings: {}
 
             
 

--- a/tests/fixtures/config/hooks/collector.py
+++ b/tests/fixtures/config/hooks/collector.py
@@ -43,3 +43,22 @@ class BasicSceneCollector(HookBaseClass):
             "This is another item that has a UI",
             "This is a the display name of another item with a UI"
         )
+
+        property_item = parent_item.create_item(
+            "plugin.property_test",
+            "Dummy item for testing properties",
+            "Property Test"
+        )
+
+        property_item.properties["path"] = "/foo/bar/image.%04d.jpg"
+
+        # set some properties on the property item for debugging
+        property_item.properties["publish_type"] = "Awesomeness"
+        property_item.properties["publish_path"] = "/foo/bar/publish/image.%04d.jpg"
+        property_item.properties["publish_name"] = "image.jpg"
+        property_item.properties["publish_version"] = "007"
+        property_item.properties["publish_dependencies"] = [
+            "/foo/bar/model.abc",
+            "/foo/bar/rig.ma"
+        ]
+

--- a/tests/fixtures/config/hooks/collector.py
+++ b/tests/fixtures/config/hooks/collector.py
@@ -53,12 +53,15 @@ class BasicSceneCollector(HookBaseClass):
         property_item.properties["path"] = "/foo/bar/image.%04d.jpg"
 
         # set some properties on the property item for debugging
-        property_item.properties["publish_type"] = "Awesomeness"
-        property_item.properties["publish_path"] = "/foo/bar/publish/image.%04d.jpg"
+
+        # dot notation
+        property_item.properties.publish_type = "Awesomeness"
+        property_item.properties.publish_path = "/foo/bar/publish/image.%04d.jpg"
+
+        # standard dict notation
         property_item.properties["publish_name"] = "image.jpg"
         property_item.properties["publish_version"] = "007"
         property_item.properties["publish_dependencies"] = [
             "/foo/bar/model.abc",
             "/foo/bar/rig.ma"
         ]
-

--- a/tests/fixtures/config/hooks/test_properties_plugin_1.py
+++ b/tests/fixtures/config/hooks/test_properties_plugin_1.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2017 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import sgtk
+
+HookBaseClass = sgtk.get_hook_baseclass()
+
+
+class PluginWithoutUi(HookBaseClass):
+    """
+    Plugin for creating generic publishes in Shotgun
+    """
+
+    @property
+    def item_filters(self):
+        return ["plugin.property_test"]
+
+    def accept(self, settings, item):
+        return {"accepted": True}
+
+    def validate(self, settings, item):
+        return self._ensure_properties_correct(settings, item)
+
+    def publish(self, settings, item):
+        self._ensure_properties_correct(settings, item)
+
+    def _ensure_properties_correct(self, settings, item):
+
+        # publish_type
+        expected_value = "Awesomeness"
+        publish_type = self.get_publish_type(settings, item)
+        if publish_type == expected_value:
+            self.logger.info("Publish type property is correct")
+        else:
+            self.logger.error(
+                "Publish type property incorrect. "
+                "Should be '%s' but is '%s'" %
+                (expected_value, publish_type)
+            )
+            return False
+
+        # publish_path
+        expected_value = "/foo/bar/publish/image.%04d.jpg"
+        publish_path = self.get_publish_path(settings, item)
+        if publish_path == expected_value:
+            self.logger.info("Publish path property is correct")
+        else:
+            self.logger.error(
+                "Publish path property incorrect. "
+                "Should be '%s' but is '%s'" %
+                (expected_value, publish_path)
+            )
+            return False
+
+        # publish_name
+        expected_value = "image.jpg"
+        publish_name = self.get_publish_name(settings, item)
+        if publish_name == expected_value:
+            self.logger.info("Publish name property is correct")
+        else:
+            self.logger.error(
+                "Publish name property incorrect. "
+                "Should be '%s' but is '%s'" %
+                (expected_value, publish_name)
+            )
+            return False
+
+        # publish_version
+        expected_value = "007"
+        publish_version = self.get_publish_version(settings, item)
+        if publish_version == expected_value:
+            self.logger.info("Publish version property is correct")
+        else:
+            self.logger.error(
+                "Publish version property incorrect. "
+                "Should be '%s' but is '%s'" %
+                (expected_value, publish_version)
+            )
+            return False
+
+        # publish_dependencies
+        expected_value = [
+            "/foo/bar/model.abc",
+            "/foo/bar/rig.ma"
+        ]
+        publish_dependencies = self.get_publish_dependencies(settings, item)
+        if publish_dependencies == expected_value:
+            self.logger.info("Publish dependencies property is correct")
+        else:
+            self.logger.error(
+                "Publish dependencies property incorrect. "
+                "Should be '%s' but is '%s'" %
+                (expected_value, publish_dependencies)
+            )
+            return False
+
+        return True

--- a/tests/fixtures/config/hooks/test_properties_plugin_1.py
+++ b/tests/fixtures/config/hooks/test_properties_plugin_1.py
@@ -31,6 +31,9 @@ class PluginWithoutUi(HookBaseClass):
     def publish(self, settings, item):
         self._ensure_properties_correct(settings, item)
 
+    def finalize(self, settings, item):
+        pass
+
     def _ensure_properties_correct(self, settings, item):
 
         # publish_type

--- a/tests/fixtures/config/hooks/test_properties_plugin_2.py
+++ b/tests/fixtures/config/hooks/test_properties_plugin_2.py
@@ -1,0 +1,110 @@
+# Copyright (c) 2017 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import sgtk
+
+HookBaseClass = sgtk.get_hook_baseclass()
+
+
+class PluginWithoutUi(HookBaseClass):
+    """
+    Plugin for creating generic publishes in Shotgun
+    """
+
+    @property
+    def item_filters(self):
+        return ["plugin.property_test"]
+
+    def accept(self, settings, item):
+        self.publish_type = "Greatness"
+        self.publish_path = "/foo/bar/baz/publish/image.%04d.jpg"
+        self.publish_name = "render.jpg"
+        return {"accepted": True}
+
+    def validate(self, settings, item):
+        return self._ensure_properties_correct(settings, item)
+
+    def publish(self, settings, item):
+        self._ensure_properties_correct(settings, item)
+
+    def _ensure_properties_correct(self, settings, item):
+
+        # for this plugin, make sure all of the publish properties match their
+        # value defined in the collector
+
+        # publish_type
+        expected_value = "Greatness"
+        publish_type = self.get_publish_type(settings, item)
+        if publish_type == expected_value:
+            self.logger.info("Publish type property is correct")
+        else:
+            self.logger.error(
+                "Publish type property incorrect. "
+                "Should be '%s' but is '%s'" %
+                (expected_value, publish_type)
+            )
+            return False
+
+        # publish_path
+        expected_value = "/foo/bar/baz/publish/image.%04d.jpg"
+        publish_path = self.get_publish_path(settings, item)
+        if publish_path == expected_value:
+            self.logger.info("Publish path property is correct")
+        else:
+            self.logger.error(
+                "Publish path property incorrect. "
+                "Should be '%s' but is '%s'" %
+                (expected_value, publish_path)
+            )
+            return False
+
+        # publish_name
+        expected_value = "render.jpg"
+        publish_name = self.get_publish_name(settings, item)
+        if publish_name == expected_value:
+            self.logger.info("Publish name property is correct")
+        else:
+            self.logger.error(
+                "Publish name property incorrect. "
+                "Should be '%s' but is '%s'" %
+                (expected_value, publish_name)
+            )
+            return False
+
+        # publish_version
+        expected_value = "007"
+        publish_version = self.get_publish_version(settings, item)
+        if publish_version == expected_value:
+            self.logger.info("Publish version property is correct")
+        else:
+            self.logger.error(
+                "Publish version property incorrect. "
+                "Should be '%s' but is '%s'" %
+                (expected_value, publish_version)
+            )
+            return False
+
+        # publish_dependencies
+        expected_value = [
+            "/foo/bar/model.abc",
+            "/foo/bar/rig.ma"
+        ]
+        publish_dependencies = self.get_publish_dependencies(settings, item)
+        if publish_dependencies == expected_value:
+            self.logger.info("Publish dependencies property is correct")
+        else:
+            self.logger.error(
+                "Publish dependencies property incorrect. "
+                "Should be '%s' but is '%s'" %
+                (expected_value, publish_dependencies)
+            )
+            return False
+
+        return True

--- a/tests/fixtures/config/hooks/test_properties_plugin_2.py
+++ b/tests/fixtures/config/hooks/test_properties_plugin_2.py
@@ -23,9 +23,9 @@ class PluginWithoutUi(HookBaseClass):
         return ["plugin.property_test"]
 
     def accept(self, settings, item):
-        self.publish_type = "Greatness"
-        self.publish_path = "/foo/bar/baz/publish/image.%04d.jpg"
-        self.publish_name = "render.jpg"
+        item.local_properties.publish_type = "Greatness"
+        item.local_properties.publish_path = "/foo/bar/baz/publish/image.%04d.jpg"
+        item.local_properties["publish_name"] = "render.jpg"
         return {"accepted": True}
 
     def validate(self, settings, item):
@@ -33,6 +33,9 @@ class PluginWithoutUi(HookBaseClass):
 
     def publish(self, settings, item):
         self._ensure_properties_correct(settings, item)
+
+    def finalize(self, settings, item):
+        pass
 
     def _ensure_properties_correct(self, settings, item):
 

--- a/tests/fixtures/config/hooks/test_properties_plugin_3.py
+++ b/tests/fixtures/config/hooks/test_properties_plugin_3.py
@@ -23,9 +23,9 @@ class PluginWithoutUi(HookBaseClass):
         return ["plugin.property_test"]
 
     def accept(self, settings, item):
-        self.publish_name = "beauty.jpg"
-        self.publish_version = "008"
-        self.publish_dependencies = []
+        item.local_properties.publish_name = "beauty.jpg"
+        item.local_properties.publish_version = "008"
+        item.local_properties["publish_dependencies"] = []
         return {"accepted": True}
 
     def validate(self, settings, item):
@@ -33,6 +33,9 @@ class PluginWithoutUi(HookBaseClass):
 
     def publish(self, settings, item):
         self._ensure_properties_correct(settings, item)
+
+    def finalize(self, settings, item):
+        pass
 
     def _ensure_properties_correct(self, settings, item):
 

--- a/tests/fixtures/config/hooks/test_properties_plugin_3.py
+++ b/tests/fixtures/config/hooks/test_properties_plugin_3.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2017 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import sgtk
+
+HookBaseClass = sgtk.get_hook_baseclass()
+
+
+class PluginWithoutUi(HookBaseClass):
+    """
+    Plugin for creating generic publishes in Shotgun
+    """
+
+    @property
+    def item_filters(self):
+        return ["plugin.property_test"]
+
+    def accept(self, settings, item):
+        self.publish_name = "beauty.jpg"
+        self.publish_version = "008"
+        self.publish_dependencies = []
+        return {"accepted": True}
+
+    def validate(self, settings, item):
+        return self._ensure_properties_correct(settings, item)
+
+    def publish(self, settings, item):
+        self._ensure_properties_correct(settings, item)
+
+    def _ensure_properties_correct(self, settings, item):
+
+        # publish_type
+        expected_value = "Awesomeness"
+        publish_type = self.get_publish_type(settings, item)
+        if publish_type == expected_value:
+            self.logger.info("Publish type property is correct")
+        else:
+            self.logger.error(
+                "Publish type property incorrect. "
+                "Should be '%s' but is '%s'" %
+                (expected_value, publish_type)
+            )
+            return False
+
+        # publish_path
+        expected_value = "/foo/bar/publish/image.%04d.jpg"
+        publish_path = self.get_publish_path(settings, item)
+        if publish_path == expected_value:
+            self.logger.info("Publish path property is correct")
+        else:
+            self.logger.error(
+                "Publish path property incorrect. "
+                "Should be '%s' but is '%s'" %
+                (expected_value, publish_path)
+            )
+            return False
+
+        # publish_name
+        expected_value = "beauty.jpg"
+        publish_name = self.get_publish_name(settings, item)
+        if publish_name == expected_value:
+            self.logger.info("Publish name property is correct")
+        else:
+            self.logger.error(
+                "Publish name property incorrect. "
+                "Should be '%s' but is '%s'" %
+                (expected_value, publish_name)
+            )
+            return False
+
+        # publish_version
+        expected_value = "008"
+        publish_version = self.get_publish_version(settings, item)
+        if publish_version == expected_value:
+            self.logger.info("Publish version property is correct")
+        else:
+            self.logger.error(
+                "Publish version property incorrect. "
+                "Should be '%s' but is '%s'" %
+                (expected_value, publish_version)
+            )
+            return False
+
+        # publish_dependencies
+        expected_value = []
+        publish_dependencies = self.get_publish_dependencies(settings, item)
+        if publish_dependencies == expected_value:
+            self.logger.info("Publish dependencies property is correct")
+        else:
+            self.logger.error(
+                "Publish dependencies property incorrect. "
+                "Should be '%s' but is '%s'" %
+                (expected_value, publish_dependencies)
+            )
+            return False
+
+        return True


### PR DESCRIPTION
This change adds a more granular interface to the base file publish plugin. Previously, publish properties such as `publish_type`, `publish_name`, and `publish_version` could only be injected into the publish item's `properties` dictionary as global values (shared by all attached plugins). The base plugin would key off of these to drive how to publish the item. This works fine when an item is being published by a single plugin. 

With these changes, a new `local_properties` property is available on collected items. This property acts like the regular `properties` but the values are stored for the current plugin only. It is now possible to set the `publish_*` values per-plugin, making it easier to build multi plugin publish workflows for a single item. 

Also, both `properties` and `local_properties` return a dictionary-like object that allows for access to data via traditional key indexing and dot notation.

The internal testing fixture for the app has been updated to include some test plugins that make use of the new `local_properties`. Running the validation in the test app will indicate if the property values are being maintained properly during execution. This includes a mix of properties being set via `properties` and `local_properties`. Here's what it looks like when run:

![image](https://user-images.githubusercontent.com/2604646/38147017-7b73cc8a-341e-11e8-9f4d-7287068c2362.png)

![image](https://user-images.githubusercontent.com/2604646/38147040-963684a4-341e-11e8-9fe2-e6051f8ae545.png)

