### PR TITLE
Workaround to make the scrollbar work properly for QT versions < 5 on…

### DIFF
--- a/python/tk_multi_publish2/publish_tree_widget/publish_tree_widget.py
+++ b/python/tk_multi_publish2/publish_tree_widget/publish_tree_widget.py
@@ -65,6 +65,9 @@ class PublishTreeWidget(QtGui.QTreeWidget):
 
         # forward double clicks on items to the items themselves
         self.itemDoubleClicked.connect(lambda i, c: i.double_clicked(c))
+        
+        # workaround to make the scrollbar work properly for QT versions < 5 on macOS
+        self.verticalScrollBar().valueChanged.connect(self.updateEditorGeometries)
 
     def set_plugin_manager(self, plugin_manager):
         """


### PR DESCRIPTION
… macOS

JIRA: SMOK-48376

There seems to be an issue in older QT versions (prior to 5) that cause
the items to never move when the scrollbar is moved.
Add a workaround to make it work in host applications that use those older QT versions.