### PR TITLE
Workaround to make the scrollbar work properly for QT version 4

### DIFF
--- a/python/tk_multi_publish2/publish_tree_widget/publish_tree_widget.py
+++ b/python/tk_multi_publish2/publish_tree_widget/publish_tree_widget.py
@@ -8,7 +8,7 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-
+import sys
 import sgtk
 from collections import defaultdict
 from sgtk.platform.qt import QtCore, QtGui
@@ -67,10 +67,12 @@ class PublishTreeWidget(QtGui.QTreeWidget):
         self.itemDoubleClicked.connect(lambda i, c: i.double_clicked(c))
         
         # workaround to make the scrollbar work properly for QT versions < 5 on macOS
-        if QtCore.__version__.startswith("4."):
-            import sys
-            if sys.platform == "darwin":
-                self.verticalScrollBar().valueChanged.connect(self.updateEditorGeometries)
+        # This look like a bug tracked on the QT side
+        # ( https://bugreports.qt.io/browse/QTBUG-27043 )
+        # This is essentially a workaround suggested on this thread
+        # ( https://stackoverflow.com/questions/15331256/qlistwidget-with-custom-widget-does-not-scroll-properly-in-mac-os )
+        if QtCore.__version__.startswith("4.") and sys.platform == "darwin":
+            self.verticalScrollBar().valueChanged.connect(self.updateEditorGeometries)
 
     def set_plugin_manager(self, plugin_manager):
         """


### PR DESCRIPTION
JIRA: SMOK-48376

There seems to be an issue in older QT versions (prior to 5) that cause
the items to never move when the scrollbar is moved.
Add a workaround to make it work in host applications that use those older QT versions.

This look like a bug tracked on the QT side ( https://bugreports.qt.io/browse/QTBUG-27043 )
This is essentially a workaround suggested on this thread ( https://stackoverflow.com/questions/15331256/qlistwidget-with-custom-widget-does-not-scroll-properly-in-mac-os ) 