### PR TITLE
Workaround to make the scrollbar work properly for QT version 4 [2]

### DIFF
--- a/python/tk_multi_publish2/publish_tree_widget/publish_tree_widget.py
+++ b/python/tk_multi_publish2/publish_tree_widget/publish_tree_widget.py
@@ -69,10 +69,13 @@ class PublishTreeWidget(QtGui.QTreeWidget):
         # workaround to make the scrollbar work properly for QT versions < 5 on macOS
         # This look like a bug tracked on the QT side
         # ( https://bugreports.qt.io/browse/QTBUG-27043 )
-        # This is essentially a workaround suggested on this thread
+        # This inspired by a workaround suggested on this thread
         # ( https://stackoverflow.com/questions/15331256/qlistwidget-with-custom-widget-does-not-scroll-properly-in-mac-os )
         if QtCore.__version__.startswith("4.") and sys.platform == "darwin":
+            self.verticalScrollBar().actionTriggered.connect(self.updateEditorGeometries)
             self.verticalScrollBar().valueChanged.connect(self.updateEditorGeometries)
+            self.verticalScrollBar().sliderMoved.connect(self.updateEditorGeometries)
+            self.verticalScrollBar().rangeChanged.connect(self.updateEditorGeometries)
 
     def set_plugin_manager(self, plugin_manager):
         """

--- a/python/tk_multi_publish2/publish_tree_widget/publish_tree_widget.py
+++ b/python/tk_multi_publish2/publish_tree_widget/publish_tree_widget.py
@@ -69,11 +69,9 @@ class PublishTreeWidget(QtGui.QTreeWidget):
         # workaround to make the scrollbar work properly for QT versions < 5 on macOS
         # This look like a bug tracked on the QT side
         # ( https://bugreports.qt.io/browse/QTBUG-27043 )
-        # This inspired by a workaround suggested on this thread
         # ( https://stackoverflow.com/questions/15331256/qlistwidget-with-custom-widget-does-not-scroll-properly-in-mac-os )
         if QtCore.__version__.startswith("4.") and sys.platform == "darwin":
             self.verticalScrollBar().actionTriggered.connect(self.updateEditorGeometries)
-            self.verticalScrollBar().valueChanged.connect(self.updateEditorGeometries)
             self.verticalScrollBar().sliderMoved.connect(self.updateEditorGeometries)
             self.verticalScrollBar().rangeChanged.connect(self.updateEditorGeometries)
 


### PR DESCRIPTION
JIRA: SMOK-48376

Follow-up to PR#72 (https://github.com/shotgunsoftware/tk-multi-publish2/pull/72)

It seem some more signals need to be connected in order for scrolling and selection to sync.