### PR TITLE
Add item's name in publish completed! and finalize complete! messages

### DIFF
--- a/python/tk_multi_publish2/processing/plugin.py
+++ b/python/tk_multi_publish2/processing/plugin.py
@@ -361,7 +361,7 @@ class PublishPlugin(PluginBase):
         :param settings: Dictionary of settings
         :param item: Item to analyze
         """
-        with self._handle_plugin_error("Publish complete!", "Error publishing: %s"):
+        with self._handle_plugin_error("Publish %s complete!" % item.name, "Error publishing: %s"):
             self._hook_instance.publish(settings, item)
 
     def run_finalize(self, settings, item):
@@ -371,7 +371,7 @@ class PublishPlugin(PluginBase):
         :param settings: Dictionary of settings
         :param item: Item to analyze
         """
-        with self._handle_plugin_error("Finalize complete!", "Error finalizing: %s"):
+        with self._handle_plugin_error("Finalize %s complete!" % item.name, "Error finalizing: %s"):
             self._hook_instance.finalize(settings, item)
 
     @contextmanager


### PR DESCRIPTION
JIRA: SMOK-48149

When publishing from Flame, we might publish multiple item and the message
Publish complete! will stay up for a while between each item published.

This is confusing for the user since the publish process might just be started.