### PR TITLE
For SG-7260, publish api fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.py[cod]
+.DS_Store
 
 # C extensions
 *.so

--- a/python/tk_multi_publish2/api/item.py
+++ b/python/tk_multi_publish2/api/item.py
@@ -26,9 +26,13 @@ _qt_pixmap_is_usable = None
 
 def _is_qt_pixmap_usable():
     """
-    Tries to import QtGui. If it fails, a message will be logged indicating
-    that thumbnail paths won't be validated.
+    Tries to import QtGui and access QPixmap. If it fails, the method returns False.
+
+    On failure, a warning will be logged. It will be logged only once.
     """
+
+    # We're using a cached state of the result of this method in order to display a warning
+    # only once.
     global _qt_pixmap_is_usable
     if _qt_pixmap_is_usable is not None:
         return _qt_pixmap_is_usable

--- a/python/tk_multi_publish2/api/item.py
+++ b/python/tk_multi_publish2/api/item.py
@@ -499,17 +499,29 @@ class PublishItem(object):
         """
         A generator that yields the immediate :ref:`publish-api-item` children of
         this item.
-
-        .. note:: :ref:`publish-api-item` instances are iterators so if you need
-            to traverse all descendant items, you can do this:
-
-            .. code-block:: python
-
-                for descendant in item:
-                    # process descendant item
         """
         for child in self._children:
             yield child
+
+    @property
+    def descendants(self):
+        """
+        A generator that recursively all the :ref:`publish-api-item`
+        children and their children of this item.
+        """
+        for item in self._visit_recursive():
+            yield item
+
+    def _visit_recursive(self):
+        """
+        Yields all the children from an item and their descendants.
+
+        :param item: The :ref:`publish-api-item` instance to visit recursively.
+        """
+        for c in self.children:
+            yield c
+            for sub_c in c.descendants:
+                yield sub_c
 
     @property
     def context(self):

--- a/python/tk_multi_publish2/api/item.py
+++ b/python/tk_multi_publish2/api/item.py
@@ -47,6 +47,7 @@ def _is_qt_pixmap_usable():
         logger.warning("Could not import QtGui.QPixmap. Thumbnail validation will not be available: %s", e)
         _qt_pixmap_is_usable = False
     else:
+        # If QApplication is not available, we can't create QPixmap objects.
         if QtGui.QApplication.instance() is None:
             logger.warning("QApplication does not exist. Thumbnail validation will not be available.")
             _qt_pixmap_is_usable = False
@@ -455,7 +456,9 @@ class PublishItem(object):
 
         :param str path: Path to a file on disk
         """
-        self._icon_path = path
+        # Do not remove this. The original version of the API validated the icon
+        # path and ensured it could be loaded into a pixmap.
+        self._icon_path = self._validate_image(path)
 
     def set_thumbnail_from_path(self, path):
         """
@@ -472,7 +475,7 @@ class PublishItem(object):
         :param str path: Path to a file on disk
         """
         # Do not remove this. The original version of the API validated the thumbnail
-        # path and ensure it could be loaded into a pixmap.
+        # path and ensured it could be loaded into a pixmap.
         self._thumbnail_path = self._validate_image(path)
 
     def _validate_image(self, path):
@@ -575,8 +578,8 @@ class PublishItem(object):
     @property
     def descendants(self):
         """
-        A generator that recursively all the :ref:`publish-api-item`
-        children and their children of this item.
+        A generator that yields all the :ref:`publish-api-item` children and their children
+        of this item.
         """
         for item in self._visit_recursive():
             yield item
@@ -584,8 +587,6 @@ class PublishItem(object):
     def _visit_recursive(self):
         """
         Yields all the children from an item and their descendants.
-
-        :param item: The :ref:`publish-api-item` instance to visit recursively.
         """
         for c in self.children:
             yield c

--- a/python/tk_multi_publish2/api/item.py
+++ b/python/tk_multi_publish2/api/item.py
@@ -34,9 +34,13 @@ def _is_qt_pixmap_usable():
         return _qt_pixmap_is_usable
 
     try:
+        # We can fail importing if the engine doesn't even support Qt.
         from sgtk.platform.qt import QtGui
-    except ImportError:
-        logger.warning("Could not import QtGui. Thumbnail validation will not be available.")
+        # We can also fail at using the QPixmap object in an engine like tk-shell
+        # that exposes a mocked-Qt module.
+        QtGui.QPixmap
+    except Exception as e:
+        logger.warning("Could not import QtGui.QPixmap. Thumbnail validation will not be available: %s", e)
         _qt_pixmap_is_usable = False
     else:
         if QtGui.QApplication.instance() is None:

--- a/python/tk_multi_publish2/api/manager.py
+++ b/python/tk_multi_publish2/api/manager.py
@@ -310,7 +310,7 @@ class PublishManager(object):
 
         return failed_to_validate
 
-    def publish(self, task_generator=None, raise_on_error=False):
+    def publish(self, task_generator=None):
         """
         Publish items in the tree.
 
@@ -351,8 +351,6 @@ class PublishManager(object):
             try:
                 task.publish()
             except Exception, e:
-                if raise_on_error:
-                    raise
                 pub_exception = e
 
             return pub_exception

--- a/python/tk_multi_publish2/api/manager.py
+++ b/python/tk_multi_publish2/api/manager.py
@@ -310,7 +310,7 @@ class PublishManager(object):
 
         return failed_to_validate
 
-    def publish(self, task_generator=None):
+    def publish(self, task_generator=None, raise_on_error=False):
         """
         Publish items in the tree.
 
@@ -338,6 +338,8 @@ class PublishManager(object):
             publish_manager.validate(task_generator=local_tasks_generator)
 
         :param task_generator: A generator of :class:`~PublishTask` instances.
+        :param bool raise_on_error: If ``True``, the publish process will raise
+            an exception instead of logging it.
         """
 
         def task_cb(task):
@@ -349,6 +351,8 @@ class PublishManager(object):
             try:
                 task.publish()
             except Exception, e:
+                if raise_on_error:
+                    raise
                 pub_exception = e
 
             return pub_exception

--- a/python/tk_multi_publish2/api/manager.py
+++ b/python/tk_multi_publish2/api/manager.py
@@ -338,8 +338,6 @@ class PublishManager(object):
             publish_manager.validate(task_generator=local_tasks_generator)
 
         :param task_generator: A generator of :class:`~PublishTask` instances.
-        :param bool raise_on_error: If ``True``, the publish process will raise
-            an exception instead of logging it.
         """
 
         def task_cb(task):

--- a/python/tk_multi_publish2/api/tree.py
+++ b/python/tk_multi_publish2/api/tree.py
@@ -178,19 +178,8 @@ class PublishTree(object):
 
         # item's are recursively iterable. this will yield all items under the
         # root.
-        for item in self._visit_recursive(self._root_item):
+        for item in self._root_item.descendants:
             yield item
-
-    def _visit_recursive(self, item):
-        """
-        Yields all the children from an item and their descendants.
-
-        :param item: The :ref:`publish-api-item` instance to visit recursively.
-        """
-        for c in item.children:
-            yield c
-            for sub_c in self._visit_recursive(c):
-                yield sub_c
 
     def clear(self, clear_persistent=False):
         """

--- a/python/tk_multi_publish2/api/tree.py
+++ b/python/tk_multi_publish2/api/tree.py
@@ -190,7 +190,9 @@ class PublishTree(object):
             which will clear non-persistent items only.
         """
 
-        for item in self._root_item.children:
+        # Create a list of children to remove, as we'll be iterating
+        # on the very items we are removing!!
+        for item in list(self._root_item.children):
             if clear_persistent or not item.persistent:
                 self.remove_item(item)
 

--- a/python/tk_multi_publish2/dialog.py
+++ b/python/tk_multi_publish2/dialog.py
@@ -1099,8 +1099,7 @@ class AppDialog(QtGui.QWidget):
 
             try:
                 self._publish_manager.publish(
-                    task_generator=self._publish_task_generator(),
-                    raise_on_error=True
+                    task_generator=self._publish_task_generator()
                 )
             except Exception, e:
                 # ensure the full error shows up in the log file
@@ -1308,6 +1307,8 @@ class AppDialog(QtGui.QWidget):
                         ui_item.STATUS_PUBLISH_ERROR,
                         str(pub_exception)
                     )
+                    # This will abort the publish process.
+                    raise pub_exception
                 else:
                     ui_item.set_status(ui_item.STATUS_PUBLISH)
 

--- a/python/tk_multi_publish2/dialog.py
+++ b/python/tk_multi_publish2/dialog.py
@@ -1099,7 +1099,9 @@ class AppDialog(QtGui.QWidget):
 
             try:
                 self._publish_manager.publish(
-                    task_generator=self._publish_task_generator())
+                    task_generator=self._publish_task_generator(),
+                    raise_on_error=True
+                )
             except Exception, e:
                 # ensure the full error shows up in the log file
                 logger.error("Publish error stack:\n%s" % (traceback.format_exc(),))

--- a/python/tk_multi_publish2/dialog.py
+++ b/python/tk_multi_publish2/dialog.py
@@ -501,7 +501,8 @@ class AppDialog(QtGui.QWidget):
                 # this is the summary item - so update all top level items and their children!
                 for top_level_item in self._publish_manager.tree.root_item.children:
                     top_level_item.description = self._summary_comment
-                    top_level_item._propagate_description_to_children()
+                    for item in top_level_item.descendants:
+                        item.description = comments
 
                 # all tasks have same description now, so set <multiple values> indicator to false
                 self._summary_comment_multiple_values = False
@@ -511,12 +512,12 @@ class AppDialog(QtGui.QWidget):
         # the "else" below means if this is a publish item
         else:
             self._current_item.description = comments
-            
+
             # <multiple values> placeholder text should not appear for individual items
             self.ui.item_comments._show_placeholder = False
 
             # if at least one task has a comment that is different than the summary description, set 
-            # <multiple values> indicator to true 
+            # <multiple values> indicator to true
             if self._summary_comment != comments:
                 self._summary_comment_multiple_values = True
 
@@ -535,15 +536,14 @@ class AppDialog(QtGui.QWidget):
                     top_level_item.thumbnail_explicit = False
 
                     # propagate the thumbnail to all descendant items
-                    for item in top_level_item:
+                    for item in top_level_item.descendants:
                         item.thumbnail = self._summary_thumbnail
                         item.thumbnail_explicit = False
         else:
             self._current_item.thumbnail = pixmap
             # specify that the new thumbnail overrides the one inherited from
             # summary
-            self._current_item.thumbnail_explicit = True 
-
+            self._current_item.thumbnail_explicit = True
 
     def _create_item_details(self, tree_item):
         """
@@ -654,7 +654,7 @@ class AppDialog(QtGui.QWidget):
                 thumbnail_has_multiple_values = True
                 break
 
-            for descendant in top_level_item:
+            for descendant in top_level_item.descendants:
                 if descendant.thumbnail_explicit:
                     # shortcut if one descendant has an explicit thumbnail
                     thumbnail_has_multiple_values = True

--- a/python/tk_multi_publish2/dialog.py
+++ b/python/tk_multi_publish2/dialog.py
@@ -1191,6 +1191,15 @@ class AppDialog(QtGui.QWidget):
         # reset the validation flag
         self._validation_run = False
 
+    def _get_tree_items(self):
+        tree_iterator = QtGui.QTreeWidgetItemIterator(self.ui.items_tree)
+        tree_items = []
+        while tree_iterator.value():
+            tree_items.append(tree_iterator.value())
+            tree_iterator += 1
+
+        return tree_items
+
     def _task_generator(self, stage_name):
         """
         This method yields tree items for our various stages. It will update the UI
@@ -1199,17 +1208,15 @@ class AppDialog(QtGui.QWidget):
         :param stage_name: Name of the current stage.
         """
 
-        tree_iterator = QtGui.QTreeWidgetItemIterator(self.ui.items_tree)
-        while tree_iterator.value():
+        list_items = self._get_tree_items()
+
+        for ui_item in list_items:
 
             if self._stop_processing_flagged:
                 # jump out of the iteration
                 break
 
-            ui_item = tree_iterator.value()
-
             if not ui_item.checked:
-                tree_iterator += 1
                 continue
 
             self._progress_handler.push(
@@ -1223,7 +1230,6 @@ class AppDialog(QtGui.QWidget):
             finally:
                 self._progress_handler.increment_progress()
                 self._progress_handler.pop()
-                tree_iterator += 1
 
     def _validate_task_generator(self, is_standalone):
         """

--- a/python/tk_multi_publish2/dialog.py
+++ b/python/tk_multi_publish2/dialog.py
@@ -1192,6 +1192,16 @@ class AppDialog(QtGui.QWidget):
         self._validation_run = False
 
     def _get_tree_items(self):
+        """
+        Retrieves all the items from the tree.
+
+        :returns: A list of QTreeItem.
+        """
+        # We used to be iterating on the items and yielding them
+        # one after the other in the _task_generator method,
+        # but that often gave us Internal C++ error about deleted objects.
+        # It seems getting everything first and them returning a flat list
+        # works.
         tree_iterator = QtGui.QTreeWidgetItemIterator(self.ui.items_tree)
         tree_items = []
         while tree_iterator.value():

--- a/python/tk_multi_publish2/progress/publish_logging.py
+++ b/python/tk_multi_publish2/progress/publish_logging.py
@@ -76,7 +76,7 @@ class PublishLogHandler(logging.Handler):
             status = self._progress_widget.INFO
 
         # request that the log manager processes the message
-        self._progress_widget.process_log_message(record.msg, status, action)
+        self._progress_widget.process_log_message(record.getMessage(), status, action)
 
 
 class PublishLogWrapper(object):

--- a/tests/python/publish_api_test_base.py
+++ b/tests/python/publish_api_test_base.py
@@ -67,12 +67,12 @@ class PublishApiTestBase(TankTestBase):
 
         self.manager = self.app.create_publish_manager()
 
-        api = self.app.import_module("tk_multi_publish2").api
-        self.PublishData = api.PublishData
-        self.PublishItem = api.PublishItem
-        self.PublishTree = api.PublishTree
-        self.PublishManager = api.PublishManager
-        self.PublishPluginInstance = api.plugins.PublishPluginInstance
+        self.api = self.app.import_module("tk_multi_publish2").api
+        self.PublishData = self.api.PublishData
+        self.PublishItem = self.api.PublishItem
+        self.PublishTree = self.api.PublishTree
+        self.PublishManager = self.api.PublishManager
+        self.PublishPluginInstance = self.api.plugins.PublishPluginInstance
 
         self.image_path = os.path.join(repo_root, "icon_256.png")
         self.dark_image_path = os.path.join(repo_root, "icon_256_dark.png")

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -169,6 +169,14 @@ class TestPublishItem(PublishApiTestBase):
         )
         self.assertIsNotNone(item.get_thumbnail_as_path())
 
+    def test_invalid_file(self):
+        """
+        Ensures an invalid file will be properly caught by the item.
+        """
+        item = self.PublishItem("test", "test", "test")
+        item.set_thumbnail_from_path(__file__)
+        self.assertIsNone(item.get_thumbnail_as_path())
+
     def test_thumbnail_from_pixmap(self):
         """
         Ensures thumbnail can be loaded from memory and can be persisted on disk.

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -109,11 +109,12 @@ class TestManager(PublishApiTestBase):
             task = MagicMock(
                 publish=Mock(side_effect=Exception("Test error!"))
             )
-            yield task
-            self.fail("Publisher should have raised an error.")
+            error = yield task
+            self.assertIsNotNone(error)
+            raise error
 
         with self.assertRaisesRegexp(Exception, "Test error!"):
-            self.manager.publish(test_nodes(), raise_on_error=True)
+            self.manager.publish(test_nodes())
 
     def test_publish_and_finalize_failures(self):
         """

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -100,6 +100,21 @@ class TestManager(PublishApiTestBase):
         # parent items, there should be two items.
         self.assertEqual(len(failures), 2)
 
+    def test_publish_raise_flag(self):
+        """
+        Ensures an exception is raised when the raise_on_error
+        flag is set.
+        """
+        def test_nodes():
+            task = MagicMock(
+                publish=Mock(side_effect=Exception("Test error!"))
+            )
+            yield task
+            self.fail("Publisher should have raised an error.")
+
+        with self.assertRaisesRegexp(Exception, "Test error!"):
+            self.manager.publish(test_nodes(), raise_on_error=True)
+
     def test_publish_and_finalize_failures(self):
         """
         Ensures publishing and finalizing report error properly.

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -86,6 +86,22 @@ class TestPublishTree(PublishApiTestBase):
         tree.clear(clear_persistent=True)
         self.assertEqual(len(list(self.manager.tree)), 0)
 
+    def test_clear_everything(self):
+        """
+        Ensures nodes are all properly deleted when calling clear.
+        """
+        # This test was written to ensure that all nodes are properly cleared the
+        # first time we called the method. An old bug had the clear remove one item
+        # out of two because we were iterating on the children of the root without
+        # making a copy of the list of items to remove first. Rookie mistake. :)
+        tree = self.manager.tree
+        for _ in range(10):
+            persistent = tree.root_item.create_item("persitent", "persistent", "persistent")
+            persistent.persistent = True
+
+        tree.clear(clear_persistent=True)
+        self.assertEqual(list(self.manager.tree), [])
+
     def test_root_deletion(self):
         """
         Ensures you can't delete the root.


### PR DESCRIPTION
Fixes a bunch of issues with the publisher API.

## Item.set_thumbnail_from_path
This method originally validated that a given path was pointing to a loadable thumbnail, but didn't after the refactor. This caused issues in certain plugins like Photoshop. In Photoshop, when we publish the current scene we put the current file name as the thumbnail for the item. If the file is a psd, then it won't be loadable by QPixmap and the thumbnail will be ignored. If the file is a JPEG or any other regular image format the thumbnail is set successfully.

This behaviour has been repaired by adding back in the validation. To do so however, I've added extra code that make the API usable even if there is no QApplication instance. As such, the API can still be used when Qt isn't available.

## Visiting descendants
During the original merge of the publish API, I changed a bit the API proposed by @josh-t because it wasn't obvious how iteration on children vs descendants worked and caused readability issues. By doing so, I broke a couple of places who still expected the `__iter__` method being available on `Item` to visit children recursively. I've now introduced a method called descendants which allows to iterate on the decendants of an `Item`.

## Publishing even with errors
We're now properly raising an error when a publish failed in the publisher.