### PR TITLE
Validates that a task is selected for every item if the setting task_required is true

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+
+# Jetbrains
+.idea/

--- a/python/tk_multi_publish2/dialog.py
+++ b/python/tk_multi_publish2/dialog.py
@@ -345,6 +345,9 @@ class AppDialog(QtGui.QWidget):
                 # top node summary
                 self._create_master_summary_details()
 
+        # Make the task validation if the setting `task_required` exists and it's True
+        self._validate_task_required()
+
     def _is_task_selection_homogeneous(self, items):
         """
         Indicates if a selection is made up only of tasks and they are all of the same item.
@@ -1399,6 +1402,9 @@ class AppDialog(QtGui.QWidget):
         if sync_required:
             self._synchronize_tree()
 
+        # Make the task validation if the setting `task_required` exists and it's True
+        self._validate_task_required()
+
     def _on_browse(self, folders=False):
         """Opens a file dialog to browse to files for publishing."""
 
@@ -1477,6 +1483,38 @@ class AppDialog(QtGui.QWidget):
 
         self.ui.main_stack.setCurrentIndex(self.PUBLISH_SCREEN)
         self._overlay.show_no_items_error()
+
+    def _validate_task_required(self):
+        """
+        Validates that a task is selected for every item and disables/enables the
+        validate and publish buttons and finally change the color for the task
+        label.
+        """
+        # Avoid validation if the setting `task_required` is False or not exists
+        if not self._bundle.get_setting("task_required"):
+            return
+
+        all_items_selected_task = True
+        for context_index in xrange(self.ui.items_tree.topLevelItemCount()):
+            context_item = self.ui.items_tree.topLevelItem(context_index)
+
+            if hasattr(context_item, "context") and not context_item.context.task:
+                all_items_selected_task = False
+                break
+
+        if not all_items_selected_task:
+            # disable buttons
+            self.ui.publish.setEnabled(False)
+            self.ui.validate.setEnabled(False)
+            # change task label color to RED
+            self.ui.context_widget.ui.task_label.setStyleSheet("color: red")
+        else:
+            # enable buttons
+            self.ui.publish.setEnabled(True)
+            self.ui.validate.setEnabled(True)
+
+            # change task label color to the default value
+            self.ui.context_widget.ui.task_label.setStyleSheet("")
 
 
 class _TaskSelection(object):


### PR DESCRIPTION
Sometimes a task is necessary for publishing an item.

For example:

`asset_root: assets/{sg_asset_type}/{Asset}/{task_name}`

When user clicks the button, the validation process detects the error 
and report it as expected.

We would like to offer users avoid having to wait for the validation 
process to correct this error.

We propose the following:

* A new optional setting `task_required` with a boolean value true/false

* If the setting exists and its value is true:

  We call a new method inside `python/tk_multi_publish2/dialog.py`
  named ``_validate_task_required`` which makes the next steps:
    
  * Checks that a task is selected for every top item 
  * Disables/Enables the validate and publish buttons 
  * Change the color for the task label to RED or the default value

The call to ``_validate_task_required`` occurs at the end of the methods:
  * ``_update_details_from_selection``
  * ``_on_item_context_change``

In order to ensure that the validation is done when user changes the task
or select another item.

![publish2-task-requiredl](https://user-images.githubusercontent.com/2762494/46911632-911bea00-cf27-11e8-9a47-0a8124aa4a0c.png)
