### PR TITLE
For SG-7260, fixes the publish and finalize API flow

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -40,11 +40,11 @@ The code below shows how to execute a complete publish using this API:
     manager.collect_files([path1, path2, path3])
 
     # validate the items to publish
-    items_failed_validation = manager.validate()
+    tasks_failed_validation = manager.validate()
 
-    # oops, some items are invalid. see if they can be fixed
-    if items_failed_validation:
-        fix_invalid_items(items_failed_validation)
+    # oops, some tasks are invalid. see if they can be fixed
+    if tasks_failed_validation:
+        fix_invalid_tasks(tasks_failed_validation)
         # try again here or bail
 
     # all good. let's publish and finalize
@@ -53,9 +53,9 @@ The code below shows how to execute a complete publish using this API:
         # If a plugin needed to version up a file name after publish
         # it would be done in the finalize.
         manager.finalize()
-    except Exception, e:
+    except Exception as error:
         logger.error("There was trouble trying to publish!")
-        logger.error("Error: %s" % (e,))
+        logger.error("Error: %s", error)
 
 See the documentation for each of these classes below for more detail on how
 to use them.

--- a/python/tk_multi_publish2/api/manager.py
+++ b/python/tk_multi_publish2/api/manager.py
@@ -255,7 +255,8 @@ class PublishManager(object):
         method on each task in the publish tree. A list of
         :class:`~PublishTask` instances that failed validation will be returned.
         An exception will be associated with every task that failed validation
-        if one was raised.
+        if one was raised. If no exception was raised, the second member of the
+        tuple will be ``None``.
 
         By default, the method will iterate over the manager's publish tree,
         validating all active tasks on all active items. To process tasks in a
@@ -296,8 +297,8 @@ class PublishManager(object):
                 is_valid = False
                 error = e
 
-            # if the task didn't validate, add it to the list of items that
-            # failed (if it's not already there).
+            # if the task didn't validate, add it to the list of tasks that
+            # failed.
             if not is_valid:
                 failed_to_validate.append((task, error))
 

--- a/python/tk_multi_publish2/dialog.py
+++ b/python/tk_multi_publish2/dialog.py
@@ -1118,9 +1118,10 @@ class AppDialog(QtGui.QWidget):
                 self._progress_handler.push("Running finalizing pass")
 
                 try:
-                    self._publish_manager.finalize(
+                    finalization_errors = self._publish_manager.finalize(
                         task_generator=self._finalize_task_generator())
-                except Exception, e:
+                    publish_failed = bool(finalization_errors)
+                except Exception:
                     # ensure the full error shows up in the log file
                     logger.error("Finalize error stack:\n%s" % (traceback.format_exc(),))
                     # and log to ui
@@ -1252,7 +1253,8 @@ class AppDialog(QtGui.QWidget):
             try:
                 # yield each child item to be acted on by the publish api
                 if isinstance(ui_item, TreeNodeTask):
-                    (is_successful, error_msg) = yield ui_item.task
+                    (is_successful, error) = yield ui_item.task
+                    error_msg = str(error)
 
                 # all other nodes are UI-only and can handle their own
                 # validation
@@ -1288,13 +1290,12 @@ class AppDialog(QtGui.QWidget):
             try:
                 # yield each child item to be acted on by the publish api
                 if isinstance(ui_item, TreeNodeTask):
-                    pub_exception = yield ui_item.task
+                    yield ui_item.task
 
                 # all other nodes are UI-only and can handle their own
                 # publishing
                 else:
                     ui_item.publish()
-                    pub_exception = None
             except Exception, e:
                 ui_item.set_status_upwards(
                     ui_item.STATUS_PUBLISH_ERROR,
@@ -1302,15 +1303,7 @@ class AppDialog(QtGui.QWidget):
                 )
                 raise
             else:
-                if pub_exception:
-                    ui_item.set_status_upwards(
-                        ui_item.STATUS_PUBLISH_ERROR,
-                        str(pub_exception)
-                    )
-                    # This will abort the publish process.
-                    raise pub_exception
-                else:
-                    ui_item.set_status(ui_item.STATUS_PUBLISH)
+                ui_item.set_status(ui_item.STATUS_PUBLISH)
 
     def _finalize_task_generator(self):
         """

--- a/python/tk_multi_publish2/dialog.py
+++ b/python/tk_multi_publish2/dialog.py
@@ -1101,7 +1101,7 @@ class AppDialog(QtGui.QWidget):
                 self._publish_manager.publish(
                     task_generator=self._publish_task_generator()
                 )
-            except Exception, e:
+            except Exception:
                 # ensure the full error shows up in the log file
                 logger.error("Publish error stack:\n%s" % (traceback.format_exc(),))
                 # and log to ui
@@ -1118,9 +1118,8 @@ class AppDialog(QtGui.QWidget):
                 self._progress_handler.push("Running finalizing pass")
 
                 try:
-                    finalization_errors = self._publish_manager.finalize(
+                    self._publish_manager.finalize(
                         task_generator=self._finalize_task_generator())
-                    publish_failed = bool(finalization_errors)
                 except Exception:
                     # ensure the full error shows up in the log file
                     logger.error("Finalize error stack:\n%s" % (traceback.format_exc(),))

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -105,12 +105,12 @@ class TestPublishItem(PublishApiTestBase):
                 # Make sure if we're trying to access the local properties in a
                 # non plugin hook that the error is caught.
                 del self.id
-                with test.assertRaisesRegexp(AttributeError, "Could not determine the id for this"):
+                with test.assertRaisesRegex(AttributeError, "Could not determine the id for this"):
                     item.local_properties["test"]
 
         # Make sure if we're trying to access the local properties in a non-hook
         # derived class that the error is caught
-        with self.assertRaisesRegexp(AttributeError, "Could not determine the current publish plugin when"):
+        with self.assertRaisesRegex(AttributeError, "Could not determine the current publish plugin when"):
             item.local_properties["test"]
 
         # Instantiating the class will run the rest defined above.
@@ -128,7 +128,7 @@ class TestPublishItem(PublishApiTestBase):
         item5 = item2.create_item("test5", "test5", "test5")
 
         # Ensure removing an item that is not a children raises an error.
-        with self.assertRaisesRegexp(sgtk.TankError, "Unable to remove child item"):
+        with self.assertRaisesRegex(sgtk.TankError, "Unable to remove child item"):
             item.remove_item(item5)
 
         children = [c.name for c in item.children]
@@ -296,12 +296,12 @@ class TestPublishItem(PublishApiTestBase):
 
         # Root and grand children of the root can't be made persistent.
         self.assertFalse(grand_child.persistent)
-        with self.assertRaisesRegexp(sgtk.TankError, "Only top-level tree items"):
+        with self.assertRaisesRegex(sgtk.TankError, "Only top-level tree items"):
             grand_child.persistent = True
         self.assertFalse(grand_child.persistent)
 
         self.assertFalse(root.persistent)
-        with self.assertRaisesRegexp(sgtk.TankError, "Only top-level tree items"):
+        with self.assertRaisesRegex(sgtk.TankError, "Only top-level tree items"):
             root.persistent = True
         self.assertFalse(root.persistent)
 
@@ -337,7 +337,7 @@ class TestPublishItem(PublishApiTestBase):
                 nb_items_processed = 0
                 for item in manager.tree:
                     for task in item.tasks:
-                        (is_valid, error_msg) = yield task
+                        (is_valid, error) = yield task
                         # The validate method of both plugins will raise an error
                         # if the the values can be retrieved.
                         # We're raising if the test passes in the validate method
@@ -347,7 +347,7 @@ class TestPublishItem(PublishApiTestBase):
                         # caught by the errorEqual.
                         self.assertFalse(is_valid)
                         self.assertEqual(
-                            error_msg,
+                            str(error),
                             "local_properties was serialized properly."
                         )
                         nb_items_processed += 1
@@ -357,8 +357,8 @@ class TestPublishItem(PublishApiTestBase):
                 # were available due to a misconfiguration error in the test.
                 self.assertNotEqual(nb_items_processed, 0)
 
-            # Validate with our custom yielder
-            self.assertEqual(len(new_manager.validate(task_yielder(new_manager))), 3)
+            # Validate with our custom yielder. Each task that fails reports an error.
+            self.assertEqual(len(new_manager.validate(task_yielder(new_manager))), 6)
 
     def _create_manager(self):
         """

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -55,11 +55,11 @@ class TestPublishTree(PublishApiTestBase):
         """
         Ensures we can't reload documents from an incorrect version.
         """
-        with self.assertRaisesRegexp(sgtk.TankError, "<missing version>"):
+        with self.assertRaisesRegex(sgtk.TankError, "<missing version>"):
             self.PublishTree.from_dict({})
 
         bad_version = 99999999
-        with self.assertRaisesRegexp(sgtk.TankError, "Unrecognized serialization version \(%s\)" % bad_version):
+        with self.assertRaisesRegex(sgtk.TankError, "Unrecognized serialization version \(%s\)" % bad_version):
             self.PublishTree.from_dict({"serialization_version": bad_version})
 
     def test_pprint(self):
@@ -106,7 +106,7 @@ class TestPublishTree(PublishApiTestBase):
         """
         Ensures you can't delete the root.
         """
-        with self.assertRaisesRegexp(sgtk.TankError, "Removing the root item is not allowed."):
+        with self.assertRaisesRegex(sgtk.TankError, "Removing the root item is not allowed."):
             self.manager.tree.remove_item(self.manager.tree.root_item)
 
     def _set_item(self, item, boolean, description, icon_path, thumb_path, local_prop, global_prop):


### PR DESCRIPTION
In order to make the API more programmer centric, I've made the following changes:
- the validate phases will return a list of  tuples of (task, exception) of each validation that failes and not a list of items. This allows to know exactly what failed. If an exception was raised for that validation, it will be left as is
- the API will yield the exception that was raised and not just the text, so the generator can infer more from the error
- the publish and finalize methods now stop at first sign of an error, just like the GUI behaves. The exception is raised back to the caller.
- Because validation now reports the number of tasks that failed publish and not items that have failed tasks, it means the error count will be equal to the number of failed tasks and not equal to the number of items with failed tasks. The previous behaviour introduced odd scenarios where a single item with two failed tasks would report that only one error was found.