### PR TITLE
Fixing bug which causes dependencies not to be properly stored

### DIFF
--- a/hooks/publish_file.py
+++ b/hooks/publish_file.py
@@ -363,8 +363,8 @@ class BasicFilePublishPlugin(HookBaseClass):
 
         # if the parent item has a publish path, include it in the list of
         # dependencies
-        if "sg_publish_path" in item.parent.properties:
-            publish_dependencies.append(item.parent.properties.sg_publish_path)
+        if "sg_publish_data" in item.parent.properties:
+            publish_dependencies.append(item.parent.properties.sg_publish_data.get('path', {}).get('local_path', ''))
 
         # handle copying of work to publish if templates are in play
         self._copy_work_to_publish(settings, item)


### PR DESCRIPTION
This pull request addresses an issue that appears to be a bug. Using the default module the dependencies are not correctly stored during the publish process.

The 'publish' method looks for the key 'sg_publish_path' in the properties of the parent item. This value doesn't seem to be stored anywhere. The changes of this pull request are looking for the key 'sg_publish_data' instead, and use its 'local_path' value if found.

Please let me know if you have any questions, comments or concerns.

Thank you for considering this pull request.