### PR TITLE
hooks/publish_file.py - Fixing bug which causes dependencies not to b…

### DIFF
--- a/hooks/publish_file.py
+++ b/hooks/publish_file.py
@@ -367,8 +367,8 @@ class BasicFilePublishPlugin(HookBaseClass):
 
         # if the parent item has a publish path, include it in the list of
         # dependencies
-        if "sg_publish_path" in item.parent.properties:
-            publish_dependencies.append(item.parent.properties.sg_publish_path)
+        if "sg_publish_data" in item.parent.properties:
+            publish_dependencies.append(item.parent.properties.sg_publish_data.get('path', {}).get('local_path', ''))
 
         # handle copying of work to publish if templates are in play
         self._copy_work_to_publish(settings, item)


### PR DESCRIPTION
**This pull request is an updated version of https://github.com/shotgunsoftware/tk-multi-publish2/pull/88. However the branch of this pull request has been rebased on to the latest version (v2.3.0).**

This pull request addresses an issue that appears to be a bug. Using the default module the dependencies are not correctly stored during the publish process.

The 'publish' method looks for the key 'sg_publish_path' in the properties of the parent item. This value doesn't seem to be stored anywhere. The changes of this pull request are looking for the key 'sg_publish_data' instead, and use its 'local_path' value if found.

Please let me know if you have any questions, comments or concerns.

Thank you for considering this pull request.