### PR TITLE
SG-9210: Resolves a QToolButton styling issue in Houdini 17.

### DIFF
--- a/python/tk_multi_publish2/progress/ui/progress_details_widget.py
+++ b/python/tk_multi_publish2/progress/ui/progress_details_widget.py
@@ -11,7 +11,7 @@ from tank.platform.qt import QtCore, QtGui
 class Ui_ProgressDetailsWidget(object):
     def setupUi(self, ProgressDetailsWidget):
         ProgressDetailsWidget.setObjectName("ProgressDetailsWidget")
-        ProgressDetailsWidget.resize(696, 358)
+        ProgressDetailsWidget.resize(370, 233)
         self.verticalLayout = QtGui.QVBoxLayout(ProgressDetailsWidget)
         self.verticalLayout.setSpacing(0)
         self.verticalLayout.setContentsMargins(0, 0, 0, 0)
@@ -28,6 +28,7 @@ class Ui_ProgressDetailsWidget(object):
         self.progress_label.setObjectName("progress_label")
         self.horizontalLayout.addWidget(self.progress_label)
         self.copy_log_button = QtGui.QToolButton(self.progress_frame)
+        self.copy_log_button.setMinimumSize(QtCore.QSize(105, 0))
         self.copy_log_button.setToolButtonStyle(QtCore.Qt.ToolButtonTextOnly)
         self.copy_log_button.setObjectName("copy_log_button")
         self.horizontalLayout.addWidget(self.copy_log_button)

--- a/resources/progress_details_widget.ui
+++ b/resources/progress_details_widget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>696</width>
-    <height>358</height>
+    <width>370</width>
+    <height>233</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -40,6 +40,12 @@
         </item>
         <item>
          <widget class="QToolButton" name="copy_log_button">
+          <property name="minimumSize">
+           <size>
+            <width>105</width>
+            <height>0</height>
+           </size>
+          </property>
           <property name="toolTip">
            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Open the publisher's log file. The log file is useful for deeper debugging of publish issues. For issues involving Shotgun Support, please include a copy of this file when submitting a support request. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>


### PR DESCRIPTION
Sets a minimum width on one QToolButton to combat a styling problem we have in Houdini 17.