### PR TITLE
SG-9941 Allow additional data to be included in publish publish

### DIFF
--- a/hooks/publish_file.py
+++ b/hooks/publish_file.py
@@ -84,6 +84,18 @@ class BasicFilePublishPlugin(HookBaseClass):
             when registering the new publish. If not available, the publishing
             will fall back to the :meth:`tank.util.register_publish` logic.
 
+        publish_fields - A dictionary of additional fields that should be used
+            for the publish. This dictionary is passed on to
+            :meth:`tank.util.register_publish` as the ``sg_fields`` keyword
+            argument.
+
+        publish_kwargs - A dictionary of kwargs that should be passed to
+            :meth:`tank.util.register_publish`. These kwargs will be used to
+            update the kwark dictionary that is passed when calling
+            :meth:`tank.util.register_publish`, meaning that any value set here
+            will supercede a value already retreived from another ``property``
+            or ``local_property``.
+
     NOTE: accessing these ``publish_*`` values on the item does not necessarily
     return the value used during publish execution. Use the corresponding
     ``get_publish_*`` methods which include fallback logic when no property is
@@ -364,6 +376,9 @@ class BasicFilePublishPlugin(HookBaseClass):
         publish_path = self.get_publish_path(settings, item)
         publish_dependencies = self.get_publish_dependencies(settings, item)
         publish_user = self.get_publish_user(settings, item)
+        publish_fields = self.get_publish_fields(settings, item)
+        # catch-all for any extra kwargs that should be passed to register_publish.
+        publish_kwargs = self.get_publish_kwargs(settings, item)
 
         # if the parent item has a publish path, include it in the list of
         # dependencies
@@ -385,8 +400,12 @@ class BasicFilePublishPlugin(HookBaseClass):
             "version_number": publish_version,
             "thumbnail_path": item.get_thumbnail_as_path(),
             "published_file_type": publish_type,
-            "dependency_paths": publish_dependencies
+            "dependency_paths": publish_dependencies,
+            "sg_fields": publish_fields
         }
+
+        # add extra kwargs
+        publish_data.update(publish_kwargs)
 
         # log the publish data for debugging
         self.logger.debug(
@@ -689,6 +708,41 @@ class BasicFilePublishPlugin(HookBaseClass):
         :return: A user entity dictionary or ``None`` if not defined.
         """
         return item.get_property("publish_user", default_value=None)
+
+    def get_publish_fields(self, settings, item):
+        """
+        Get additional fields that should be used for the publish. This
+        dictionary is passed on to :meth:`tank.util.register_publish` as the
+        ``sg_fields`` keyword argument.
+
+        If publish_fields is not defined as a ``property`` or
+        ``local_property``, this method will return an empty dictionary.
+
+        :param settings: This plugin instance's configured settings
+        :param item: The item to determine the publish template for
+
+        :return: A dictionary of field names and values for those fields.
+        """
+        return item.get_property("publish_fields", default_value={})
+
+    def get_publish_kwargs(self, settings, item):
+        """
+        Get kwargs that should be passed to :meth:`tank.util.register_publish`.
+        These kwargs will be used to update the kwark dictionary that is passed
+        when calling :meth:`tank.util.register_publish`, meaning that any value
+        set here will supercede a value already retreived from another
+        ``property`` or ``local_property``.
+
+        If publish_kwargs is not defined as a ``property`` or
+        ``local_property``, this method will return an empty dictionary.
+
+        :param settings: This plugin instance's configured settings
+        :param item: The item to determine the publish template for
+
+        :return: A dictionary of kwargs to be passed to
+                 :meth:`tank.util.register_publish`.
+        """
+        return item.get_property("publish_kwargs", default_value={})
 
     ############################################################################
     # protected methods

--- a/hooks/publish_file.py
+++ b/hooks/publish_file.py
@@ -91,9 +91,9 @@ class BasicFilePublishPlugin(HookBaseClass):
 
         publish_kwargs - A dictionary of kwargs that should be passed to
             :meth:`tank.util.register_publish`. These kwargs will be used to
-            update the kwark dictionary that is passed when calling
+            update the kwarg dictionary that is passed when calling
             :meth:`tank.util.register_publish`, meaning that any value set here
-            will supercede a value already retreived from another ``property``
+            will supersede a value already retrieved from another ``property``
             or ``local_property``.
 
     NOTE: accessing these ``publish_*`` values on the item does not necessarily
@@ -728,9 +728,9 @@ class BasicFilePublishPlugin(HookBaseClass):
     def get_publish_kwargs(self, settings, item):
         """
         Get kwargs that should be passed to :meth:`tank.util.register_publish`.
-        These kwargs will be used to update the kwark dictionary that is passed
+        These kwargs will be used to update the kwarg dictionary that is passed
         when calling :meth:`tank.util.register_publish`, meaning that any value
-        set here will supercede a value already retreived from another
+        set here will supersede a value already retrieved from another
         ``property`` or ``local_property``.
 
         If publish_kwargs is not defined as a ``property`` or

--- a/hooks/publish_file.py
+++ b/hooks/publish_file.py
@@ -84,17 +84,16 @@ class BasicFilePublishPlugin(HookBaseClass):
             when registering the new publish. If not available, the publishing
             will fall back to the :meth:`tank.util.register_publish` logic.
 
-        publish_fields - A dictionary of additional fields that should be used
-            for the publish. This dictionary is passed on to
+        publish_fields - If set, will be passed to
             :meth:`tank.util.register_publish` as the ``sg_fields`` keyword
-            argument.
+            argument. A dictionary of additional fields that should be used
+            for the publish entity in Shotgun.
 
-        publish_kwargs - A dictionary of kwargs that should be passed to
-            :meth:`tank.util.register_publish`. These kwargs will be used to
-            update the kwarg dictionary that is passed when calling
-            :meth:`tank.util.register_publish`, meaning that any value set here
-            will supersede a value already retrieved from another ``property``
-            or ``local_property``.
+        publish_kwargs - If set, will be used to update the dictionary of kwargs
+            passed to :meth:`tank.util.register_publish`. Because this
+            dictionary updates the kwargs built from other ``property``
+            and ``local_property`` values, any kwargs set in this property will
+            supersede those values.
 
     NOTE: accessing these ``publish_*`` values on the item does not necessarily
     return the value used during publish execution. Use the corresponding

--- a/tests/fixtures/config/core/hooks/pick_environment.py
+++ b/tests/fixtures/config/core/hooks/pick_environment.py
@@ -22,5 +22,7 @@ class PickEnvironment(Hook):
 
         if "PUBLISH2_API_TEST" in os.environ:
             return "api_test"
+        elif "PUBLISH2_EXTRA_FIELDS_TEST" in os.environ:
+            return "extra_fields_test"
         else:
             return "test"

--- a/tests/fixtures/config/env/extra_fields_test.yml
+++ b/tests/fixtures/config/env/extra_fields_test.yml
@@ -1,0 +1,42 @@
+# Copyright (c) 2019 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+#
+
+# All the bundles are relative to this repo, except for tk-shell, as there
+# is little chance it will need to be edited. All other repos are common
+# on dev machines.
+
+engines:
+  tk-shell:
+    location:
+        type: path
+        path: $SHOTGUN_EXTERNAL_REPOS_ROOT/tk-shell
+    apps:
+      tk-multi-publish2:
+        location:
+          type: path
+          path: $REPO_ROOT
+        help_url: https://support.shotgunsoftware.com/hc/en-us/articles/115000068574-Integrations-User-Guide#The%20Publisher
+        collector: "{self}/collector.py:{config}/api_collector.py"
+        publish_plugins:
+          - name: Extra Fields Publish
+            hook: "{self}/publish_file.py:{config}/extra_fields.py"
+            settings: {}
+        post_phase: "{self}/post_phase.py:{config}/post_phase_test.py"
+
+frameworks:
+  tk-framework-qtwidgets_v2.x.x:
+    location:
+      type: path
+      path: $SHOTGUN_EXTERNAL_REPOS_ROOT/tk-framework-qtwidgets
+  tk-framework-shotgunutils_v5.x.x:
+    location:
+      type: path
+      path: $SHOTGUN_EXTERNAL_REPOS_ROOT/tk-framework-shotgunutils

--- a/tests/fixtures/config/hooks/extra_fields.py
+++ b/tests/fixtures/config/hooks/extra_fields.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2019 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import os
+import datetime
+
+import sgtk
+
+HookBaseClass = sgtk.get_hook_baseclass()
+
+
+class GenericLocalPlugin(HookBaseClass):
+    """
+    This should process the item locally...
+    """
+
+    @property
+    def name(self):
+        return "Publish Plugin with extra fields"
+
+    @property
+    def description(self):
+        return "This plugin should add/modify 'created_at', 'comment' and 'sg_field_test' fields \
+            to the Published File.  Note that the 'sg_field_test' field must exist, or this will \
+            generate an error."
+
+    @property
+    def settings(self):
+        return super(GenericLocalPlugin, self).settings
+
+    @property
+    def item_filters(self):
+        return ["generic.item"]
+
+    def accept(self, settings, item):
+        item.local_properties.publish_kwargs = {
+            "created_at": datetime.datetime.now() - datetime.timedelta(days=(3 * 365)),
+            "comment": "A different description"
+        }
+        item.local_properties.publish_fields = {
+            "sg_field_test": "some value"
+        }
+        item.local_properties.plugin_name = "extra_fields"
+        item.properties.path = __file__
+        return {"accepted": True}
+
+    def validate(self, settings, item):
+        if "TEST_LOCAL_PROPERTIES" in os.environ:
+            # local properties was properly set, so make sure it raises an error.
+            # see test_item:test_local_properties_persistance for more info.
+            if item.local_properties.plugin_name == "extra_fields":
+                raise Exception("local_properties was serialized properly.")
+        self.logger.debug("Executing extra_fields plugin validate.")
+        return super(GenericLocalPlugin, self).validate(settings, item)
+
+    def publish(self, settings, item):
+        self.logger.debug("Executing extra_fields plugin publish.")
+        super(GenericLocalPlugin, self).publish(settings, item)
+        # Mockgun doesn't properly set the link_type field, so we'll do it ourselves
+        # so later calls to resolve_publish_path do not fail.
+        item.properties.sg_publish_data["path"]["link_type"] = "web"
+
+    def finalize(self, settings, item):
+        self.logger.debug("Executing extra_fields plugin finalize.")
+        super(GenericLocalPlugin, self).finalize(settings, item)

--- a/tests/test_basic_publish_plugin.py
+++ b/tests/test_basic_publish_plugin.py
@@ -85,28 +85,13 @@ class TestBasicPublishPlugin(PublishApiTestBase):
             "publish_fields": {"publish_fields key": "publish_fields value"},
             "publish_kwargs": {"publish_kwargs_key": "publish_kwargs value"},
         }
-        item_dict = {
-            "active": True,
-            "allows_context_change": False,
-            "children": [],
-            "context": None,
-            "description": "description value",
-            "enabled": True,
-            "expanded": True,
-            "global_properties": global_props_dict,
-            "icon_path": "icon path value",
-            "local_properties": {},
-            "name": "name value",
-            "persistent": False,
-            "tasks": [],
-            "thumbnail_enabled": False,
-            "thumbnail_explicit": False,
-            "thumbnail_path": "thumbnail path value",
-            "type_display": "type display value",
-            "type_spec": "type spec value",
-        }
+        item_dict = {"description": "description value", "thumbnail_path": "thumbnail_path value"}
         parent = self.PublishItem("blah", "blah", "blah")
-        publish_item = self.PublishItem.from_dict(item_dict, 1, parent=parent)
+        publish_item = self.PublishItem("baz", "baz", "baz")
+        publish_item._parent = parent
+        publish_item._global_properties = self.PublishData.from_dict(global_props_dict)
+        publish_item._description = item_dict["description"]
+        publish_item._thumbnail_path = item_dict["thumbnail_path"]
 
         # ensure that register_publish is called with the expected data
         with mock.patch("sgtk.util.register_publish") as register_publish_mock:


### PR DESCRIPTION
Update the publish hook to allow additional fields to be set on the publish through item properties.