### PR TITLE
Update manager.py

### DIFF
--- a/python/tk_multi_publish2/api/manager.py
+++ b/python/tk_multi_publish2/api/manager.py
@@ -548,7 +548,7 @@ class PublishManager(object):
                 # current app instance.
                 for settings in context_settings:
                     if settings.get("app_instance") == self._bundle.instance_name:
-                        app_settings = settings
+                        app_settings = settings.get('settings')
             elif len(context_settings) == 1:
                 app_settings = context_settings[0]["settings"]
 


### PR DESCRIPTION
Small error in code.
Gives errors when you have multiple app instances configured. 
The app_settings needs to return the correct settings dictionary otherwise app_settings[self.CONFIG_PLUGIN_DEFINITIONS] fails to find the correct key.