### PR TITLE
Fix do_validate invocation with a lambda function

### DIFF
--- a/python/tk_multi_publish2/dialog.py
+++ b/python/tk_multi_publish2/dialog.py
@@ -117,7 +117,7 @@ class AppDialog(QtGui.QWidget):
         self.ui.drag_progress_message.hide()
 
         # buttons
-        self.ui.validate.clicked.connect(self.do_validate)
+        self.ui.validate.clicked.connect(lambda: self.do_validate())
         self.ui.publish.clicked.connect(self.do_publish)
         self.ui.close.clicked.connect(self.close)
         self.ui.close.hide()

--- a/python/tk_multi_publish2/dialog.py
+++ b/python/tk_multi_publish2/dialog.py
@@ -117,10 +117,12 @@ class AppDialog(QtGui.QWidget):
         self.ui.drag_progress_message.hide()
 
         # buttons
-        self.ui.validate.clicked.connect(lambda: self.do_validate())
         self.ui.publish.clicked.connect(self.do_publish)
         self.ui.close.clicked.connect(self.close)
         self.ui.close.hide()
+        # do_validate is invoked using a lambda function because it receives custom parameters
+        # https://eli.thegreenplace.net/2011/04/25/passing-extra-arguments-to-pyqt-slot/
+        self.ui.validate.clicked.connect(lambda: self.do_validate())
 
         # overlay
         self._overlay = SummaryOverlay(self.ui.main_frame)


### PR DESCRIPTION
When `tk-multi-publish2` invokes the method `do_validate` it isn't passing the parameter value `is_standalone` explicitely. 

https://github.com/shotgunsoftware/tk-multi-publish2/blob/master/python/tk_multi_publish2/dialog.py#L120

In the method `do_validate`, the parameter `is_standalone` has `True` by default.

We found that in VRED 2019.X the value that arrives to this method is `True` but in VRED 2020.X is `False`.

According to multiple articles like this https://eli.thegreenplace.net/2011/04/25/passing-extra-arguments-to-pyqt-slot/

A workaround is to invoke the method using `lambda` function. We propose to change this invocation:

Current:
`self.ui.validate.clicked.connect(self.do_validate)`

Proposal:
`self.ui.validate.clicked.connect(lambda: self.do_validate())`