### PR TITLE
SG-10273 Logging from publish console now bubbles up to std toolkit loggers

### DIFF
--- a/python/tk_multi_publish2/progress/publish_logging.py
+++ b/python/tk_multi_publish2/progress/publish_logging.py
@@ -96,16 +96,6 @@ class PublishLogWrapper(object):
         full_log_path = "%s.hook" % self._bundle.logger.name
 
         self._logger = logging.getLogger(full_log_path)
-
-        # seal the logger - this will prevent any log messages
-        # emitted by the publish hooks to propagate up
-        # in the hierarchy and be picked up by engine loggers.
-        # The reason we are doing this is because it may seem odd
-        # to get plugin info in for example the maya console.
-        # more importantly, it will appear in the shotgun engine
-        # in a dialog window after app exit which is non-ideal.
-        self._logger.propagate = False
-
         self._handler = PublishLogHandler(progress_widget)
 
         # and handle it in the UI


### PR DESCRIPTION
This fix removes the 'block' that was previously in place in order to not bubble up log messages from the publish hooks to the official tk loggers (console and log files) but keep them only in the publish log console. 

This means that all logging generated by the publisher is now written to disk as well as to any log console that the engine implements, which makes things more consistent and makes troubleshooting and support easier.