### PR TITLE
Allow user to launch the Publisher UI from another application

### DIFF
--- a/python/tk_multi_publish2/__init__.py
+++ b/python/tk_multi_publish2/__init__.py
@@ -1,11 +1,11 @@
 # Copyright (c) 2017 Shotgun Software Inc.
-# 
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import sgtk
@@ -26,7 +26,7 @@ def show_dialog(app):
     display_name = sgtk.platform.current_bundle().get_setting("display_name")
 
     # start ui
-    app.engine.show_dialog(display_name, app, AppDialog)
+    return app.engine.show_dialog(display_name, app, AppDialog)
 
 
 


### PR DESCRIPTION
Return the dialog object once the Publisher is built to be able to call it from another application, already populated with a list of files for example

```
import sgtk

FILE_LIST = [r"C:\Users\Barbara\Pictures\td2_1.jpg"]

# Build the context we want to publish files from
ctx = tk.context_from_entity("Task", 9753)

# Get the publish app from the current engine (tk-desktop)
tk_multi_publish2_app = sgtk.platform.current_engine().apps.get("tk-multi-publish2")
tk_multi_publish2_module = tk_multi_publish2_app.import_module("tk_multi_publish2")

# Display the UI and fill it with a list of files and the previous context
publish_dialog = tk_multi_publish2_module.show_dialog(tk_multi_publish2_app)
publish_dialog._on_drop(FILE_LIST)
publish_dialog._on_item_context_change(ctx)
```

And the result of my Python code executed from the Desktop python console

![image](https://user-images.githubusercontent.com/38566472/62278122-bd1d4300-b447-11e9-8fb9-5604a6cbf665.png)

