### PR TITLE
SG-8015 add support for PDF uploads

### DIFF
--- a/hooks/collector.py
+++ b/hooks/collector.py
@@ -89,11 +89,6 @@ class BasicSceneCollector(HookBaseClass):
                     "icon": self._get_icon_path("hiero.png"),
                     "item_type": "file.hiero",
                 },
-                "PDF": {
-                    "extensions": ["pdf"],
-                    "icon": self._get_icon_path("texture.png"),
-                    "item_type": "file.pdf",
-                },
                 "Houdini Scene": {
                     "extensions": ["hip", "hipnc"],
                     "icon": self._get_icon_path("houdini.png"),
@@ -128,6 +123,11 @@ class BasicSceneCollector(HookBaseClass):
                     "extensions": ["tif", "tiff", "tx", "tga", "dds", "rat"],
                     "icon": self._get_icon_path("texture.png"),
                     "item_type": "file.texture",
+                },
+                "PDF": {
+                    "extensions": ["pdf"],
+                    "icon": self._get_icon_path("file.png"),
+                    "item_type": "file.image",
                 },
             }
 

--- a/hooks/collector.py
+++ b/hooks/collector.py
@@ -89,6 +89,11 @@ class BasicSceneCollector(HookBaseClass):
                     "icon": self._get_icon_path("hiero.png"),
                     "item_type": "file.hiero",
                 },
+                "PDF": {
+                    "extensions": ["pdf"],
+                    "icon": self._get_icon_path("texture.png"),
+                    "item_type": "file.pdf",
+                },
                 "Houdini Scene": {
                     "extensions": ["hip", "hipnc"],
                     "icon": self._get_icon_path("houdini.png"),

--- a/hooks/publish_file.py
+++ b/hooks/publish_file.py
@@ -206,7 +206,7 @@ class BasicFilePublishPlugin(HookBaseClass):
                     ["Texture", "tiff", "tx", "tga", "dds"],
                     ["Image", "jpeg", "jpg", "png"],
                     ["Movie", "mov", "mp4"],
-                    ["PDF","pdf"],
+                    ["PDF", "pdf"],
                 ],
                 "description": (
                     "List of file types to include. Each entry in the list "

--- a/hooks/publish_file.py
+++ b/hooks/publish_file.py
@@ -206,6 +206,7 @@ class BasicFilePublishPlugin(HookBaseClass):
                     ["Texture", "tiff", "tx", "tga", "dds"],
                     ["Image", "jpeg", "jpg", "png"],
                     ["Movie", "mov", "mp4"],
+                    ["PDF","pdf"],
                 ],
                 "description": (
                     "List of file types to include. Each entry in the list "

--- a/hooks/upload_version.py
+++ b/hooks/upload_version.py
@@ -115,7 +115,7 @@ class UploadVersionPlugin(HookBaseClass):
         """
 
         # we use "video" since that's the mimetype category.
-        return ["file.image", "file.video", "file.pdf"]
+        return ["file.image", "file.video"]
 
     def accept(self, settings, item):
         """

--- a/hooks/upload_version.py
+++ b/hooks/upload_version.py
@@ -88,7 +88,7 @@ class UploadVersionPlugin(HookBaseClass):
         return {
             "File Extensions": {
                 "type": "str",
-                "default": "jpeg, jpg, png, mov, mp4",
+                "default": "jpeg, jpg, png, mov, mp4, pdf",
                 "description": "File Extensions of files to include"
             },
             "Upload": {
@@ -115,7 +115,7 @@ class UploadVersionPlugin(HookBaseClass):
         """
 
         # we use "video" since that's the mimetype category.
-        return ["file.image", "file.video"]
+        return ["file.image", "file.video", "file.pdf"]
 
     def accept(self, settings, item):
         """


### PR DESCRIPTION
This PR adds support for PDF files.
It allows PDFs to be uploaded as versions which then become reviewable in Shotgun.
<img width="220" alt="Shotgun__Publish" src="https://user-images.githubusercontent.com/3777228/62881236-3f024b80-bd27-11e9-89a3-583c76aa006e.png">
This will also generate a `PDF` `PublishedFileType` in SG when published.
Not sure if it should be shortened to PDF or expanded to Portable Document Format

Also I opted to classify the pdf as `file.image`, but perhaps a better classification would be `file.document`?