### PR TITLE
SHOT-3115 Fixes an issue accessing the clipboard on PySide2

### DIFF
--- a/python/tk_multi_publish2/progress/progress_handler.py
+++ b/python/tk_multi_publish2/progress/progress_handler.py
@@ -142,8 +142,7 @@ class ProgressHandler(object):
         Copy the log to the clipboard
         """
         logger.debug("Copying %d log messages to clipboard..." % len(self._log_messages))
-        app = QtCore.QCoreApplication.instance()
-        app.clipboard().setText("\n".join(self._log_messages))
+        QtGui.QApplication.clipboard().setText("\n".join(self._log_messages))
 
     def process_log_message(self, message, status, action):
         """


### PR DESCRIPTION
The "Copy to Clipboard" action is no longer available in engines using PySide2 as the **QCoreApplication** class doesn't have a **clipboard** attribute anymore.

![image](https://user-images.githubusercontent.com/38566472/66123828-33265d80-e5e3-11e9-9392-4689f6cd1583.png)

![image-2019-09-04-19-02-59-398](https://user-images.githubusercontent.com/38566472/66123976-8ac4c900-e5e3-11e9-9d32-6bd8faeb8048.png)

To be fully compatible with both PySide and PySide2, we're replacing the way we call the "clipboard()" method
