### PR TITLE
SG-41996 Feature/summary display

### DIFF
--- a/python/tk_multi_publish2/dialog.py
+++ b/python/tk_multi_publish2/dialog.py
@@ -696,6 +696,7 @@ class AppDialog(QtGui.QWidget):
 
         else:
             summary_text = "<p>The following items will be processed:</p>"
+            summary_text += "<style>ul { margin-left:-20px; }</style>"
             summary_text += "".join(["<p>%s</p>" % line for line in summary])
 
         self.ui.item_summary.setText(summary_text)

--- a/python/tk_multi_publish2/publish_tree_widget/tree_node_item.py
+++ b/python/tk_multi_publish2/publish_tree_widget/tree_node_item.py
@@ -73,9 +73,12 @@ class TreeNodeItem(TreeNodeBase):
     def __str__(self):
         return "%s %s" % (self._item.type_display, self._item.name)
 
-    def create_summary(self):
+    def create_summary(self, level=0):
         """
         Creates summary of actions
+
+        :param level: Indentation level of this item lives within the tree.
+        :type level: int
 
         :returns: List of strings
         """
@@ -91,16 +94,23 @@ class TreeNodeItem(TreeNodeBase):
                     task_summaries.extend(child_item.create_summary())
                 else:
                     # sub-items
-                    items_summaries.extend(child_item.create_summary())
+                    items_summaries.extend(child_item.create_summary(level + 1))
 
             summary = []
 
             if len(task_summaries) > 0:
 
-                summary_str = "<b>%s</b><br>" % self.item.name
-                summary_str += "<br>".join(
-                    ["&ndash; %s" % task_summary for task_summary in task_summaries]
+                summary_str = "<ul><li>" * level
+                summary_str += "<b>%s</b>" % self.item.name
+                summary_str += '<ul style="list-style-type:circle;">'
+                summary_str += "".join(
+                    [
+                        "<li><i>%s</i></li>" % task_summary
+                        for task_summary in task_summaries
+                    ]
                 )
+                summary_str += "</ul>"
+                summary_str += "</li></ul>" * level
                 summary.append(summary_str)
 
             summary.extend(items_summaries)


### PR DESCRIPTION
Update to the summary display to make it easier for artists to determine what tasks are going to happen.  Having a flattened list was confusing to artists, so have updated it to be an indented, bullet point list, as displayed below

![image](https://user-images.githubusercontent.com/14952660/68115307-06ba7580-fef0-11e9-88a7-1a79f2b65841.png)

 