### PR TITLE
SG-14693 serialize tree bug fix

### DIFF
--- a/python/tk_multi_publish2/api/tree.py
+++ b/python/tk_multi_publish2/api/tree.py
@@ -352,7 +352,7 @@ class _PublishTreeEncoder(json.JSONEncoder):
                 "name": data.name
             }
         else:
-            return super(_PublishTreeEncoder).default(data)
+            return super(_PublishTreeEncoder, self).default(data)
 
 
 def _json_to_objects(data):

--- a/python/tk_multi_publish2/api/tree.py
+++ b/python/tk_multi_publish2/api/tree.py
@@ -266,7 +266,7 @@ class PublishTree(object):
 
     def save(self, file_obj):
         """
-        Write a json-serialized representation of the publish tree to the
+        Writes a json-serialized representation of the publish tree to the
         supplied file-like object.
         """
         try:

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -36,7 +36,6 @@ class TestPublishTree(PublishApiTestBase):
         # Create some items that will modify
         tree = self.manager.tree
         # Make sure we are working with a clean tree.
-        tree.clear()
         item = tree.root_item.create_item("item.a", "Item A", "Item A")
         child = item.create_item("item.b", "Item B", "Item B")
 
@@ -57,43 +56,23 @@ class TestPublishTree(PublishApiTestBase):
         self.maxDiff = None
         self.assertEqual(before_load, after_load)
 
-        # leave the tree in a clean state
-        tree.clear()
-
     def test_unserializable_tree(self):
         """
         Tests that if you store an unserializable object on an item, it will fail with a
         "is not JSON serializable" TypeError.
         """
-        # Indirectly create tasks, since we can't create them directly without a
-        # PublishPluginInstance object.
-        self.manager.collect_session()
 
         # Create some items that will modify
         tree = self.manager.tree
-        # Make sure we are working with a clean tree.
-        tree.clear()
 
         item = tree.root_item.create_item("item.a", "Item A", "Item A")
-
-        # Create a datetime object as this can't be serialized.
-        datetime_now = datetime.datetime.now()
-
-        # Touch every property of an item.
-        self._set_item(
-            item, True, "Description 1", "/a/b/c.png", "/d/e/f.png", datetime_now, "global"
-        )
+        # Store a datetime object as this can't be serialized.
+        item.properties["dateteime"] = datetime.datetime.now()
 
         fd, temp_file_path = tempfile.mkstemp()
-
-        # Escape the special characters that come from the repr.
-        escaped_date_time_string = re.escape(repr(datetime_now))
-
         # Check that we get the error we expect.
-        with self.assertRaisesRegex(TypeError, "%s is not JSON serializable" % escaped_date_time_string):
+        with self.assertRaisesRegex(TypeError, "datetime.* is not JSON serializable" ):
             self.manager.save(temp_file_path)
-        # Leave the tree in a clean state.
-        tree.clear()
 
     def test_bad_document_version(self):
         """

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -8,8 +8,8 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
+from StringIO import StringIO
 import tempfile
-import re
 import datetime
 
 from mock import patch
@@ -69,10 +69,9 @@ class TestPublishTree(PublishApiTestBase):
         # Store a datetime object as this can't be serialized.
         item.properties["dateteime"] = datetime.datetime.now()
 
-        fd, temp_file_path = tempfile.mkstemp()
         # Check that we get the error we expect.
-        with self.assertRaisesRegex(TypeError, "datetime.* is not JSON serializable" ):
-            self.manager.save(temp_file_path)
+        with self.assertRaisesRegex(TypeError, "datetime.* is not JSON serializable"):
+            tree.save(StringIO())
 
     def test_bad_document_version(self):
         """


### PR DESCRIPTION
Fixes bug where a typo in the super call, meant super wasn't being passed an instance.
This meant you got an error if you tried to serialize a tree.