### PR TITLE
Added support for Nuke tree serialization

### DIFF
--- a/python/tk_multi_publish2/api/tree.py
+++ b/python/tk_multi_publish2/api/tree.py
@@ -345,15 +345,6 @@ class _PublishTreeEncoder(json.JSONEncoder):
     """
     def default(self, data):
         
-        is_nuke_session = False
-        
-        try:
-            import nuke
-        except ImportError:
-            pass
-        else:
-            is_nuke_session = True
-            
         if isinstance(data, PublishTree):
             return data.to_dict()
         elif isinstance(data, sgtk.Template):

--- a/python/tk_multi_publish2/api/tree.py
+++ b/python/tk_multi_publish2/api/tree.py
@@ -344,6 +344,16 @@ class _PublishTreeEncoder(json.JSONEncoder):
     Implements the json encoder interface for custom publish tree serialization.
     """
     def default(self, data):
+        
+        is_nuke_session = False
+        
+        try:
+            import nuke
+        except ImportError:
+            pass
+        else:
+            is_nuke_session = True
+            
         if isinstance(data, PublishTree):
             return data.to_dict()
         elif isinstance(data, sgtk.Template):
@@ -351,10 +361,23 @@ class _PublishTreeEncoder(json.JSONEncoder):
                 "_sgtk_custom_type": "sgtk.Template",
                 "name": data.name
             }
+        elif sgtk.platform.current_engine() == 'tk-nuke':
+            import nuke
+            if isinstance(data, nuke.Gizmo):
+                return {
+                    "_sgtk_custom_type": "sgtk.tk-nuke-writenode",
+                    "name": data.name()
+                }
         else:
             return super(_PublishTreeEncoder).default(data)
 
-
+def get_dcc():
+    try:
+        import nuke
+    except ImportError:
+        pass
+    else:
+        return 't
 def _json_to_objects(data):
     """
     Check if an dictionary is actually representing a Toolkit object and

--- a/python/tk_multi_publish2/api/tree.py
+++ b/python/tk_multi_publish2/api/tree.py
@@ -362,13 +362,7 @@ class _PublishTreeEncoder(json.JSONEncoder):
         else:
             return super(_PublishTreeEncoder).default(data)
 
-def get_dcc():
-    try:
-        import nuke
-    except ImportError:
-        pass
-    else:
-        return 't
+
 def _json_to_objects(data):
     """
     Check if an dictionary is actually representing a Toolkit object and


### PR DESCRIPTION
When publishing using farm_wrapper and serializing the publish tree in Nuke, the presence of a nuke node (eg the writenode) causes the tree.save method to error. Whilst this may be pointing to another greater bug in the code ( `super(_PublishTreeEncoder).default(data)` errors saying the parent class has no attribute `default`) a workaround is to gracefully handle writenodes before the default return is called. 

This workaround checks that we're in a nuke environment before importing nuke and checking the data is an instance of a nuke.Gizmo. IF it is a gizmo, we serialise the name of the node.

# Feature Request # 

It will probably be necessary to catch other publish types in this code, and if so, perhaps it should be exposed as a hook so studios won't need to fork this code to define how custom items are serialized. 

