### PR TITLE
Fix tree item expand indicator not displayed.

### DIFF
--- a/python/tk_multi_publish2/publish_tree_widget/publish_tree_widget.py
+++ b/python/tk_multi_publish2/publish_tree_widget/publish_tree_widget.py
@@ -120,13 +120,13 @@ class PublishTreeWidget(QtGui.QTreeWidget):
             ui_task = TreeNodeTask(task, ui_item)
             self.__created_items.append(ui_task)
 
-        # ensure the expand indicator is shown/hidden depending on child
-        # visibility
-        ui_item.update_expand_indicator()
-
         for child in item.children:
             self._build_item_tree_r(child, checked, level + 1, ui_item)
 
+        # ensure the expand indicator is shown/hidden depending on child
+        # visibility
+        ui_item.update_expand_indicator()
+            
         # lastly, handle the item level check state.
         # if the item has been marked as checked=False
         # uncheck it now (which will affect all children)


### PR DESCRIPTION
Make sure to update the expand indicator after both item tasks and item children have been added to the tree.