### PR TITLE
Add context widget flag on items

### DIFF
--- a/python/tk_multi_publish2/api/item.py
+++ b/python/tk_multi_publish2/api/item.py
@@ -72,6 +72,7 @@ class PublishItem(object):
     __slots__ = [
         "_active",
         "_allows_context_change",
+        "_allows_context_widget",
         "_children",
         "_context",
         "_created_temp_files",
@@ -179,6 +180,7 @@ class PublishItem(object):
 
         self._active = True
         self._allows_context_change = True
+        self._allows_context_widget = False
         self._children = []
         self._context = None
         self._created_temp_files = []
@@ -630,6 +632,22 @@ class PublishItem(object):
         Enable/disable context change for this item.
         """
         self._allows_context_change = allow
+
+    @property
+    def context_widget(self):
+        """
+        Enable/disable context change for this item.
+
+        Default is ``True``
+        """
+        return self._allows_context_widget
+
+    @context_widget.setter
+    def context_widget(self, allow):
+        """
+        Enable/disable context change for this item.
+        """
+        self._allows_context_widget = allow 
 
     @property
     def description(self):

--- a/python/tk_multi_publish2/dialog.py
+++ b/python/tk_multi_publish2/dialog.py
@@ -617,7 +617,7 @@ class AppDialog(QtGui.QWidget):
         # Items with default thumbnails should still be able to have override thumbnails set by the user
         self.ui.item_thumbnail.setEnabled(True)
 
-        if item.parent.is_root:
+        if item.parent.is_root or item.context_widget:
             self.ui.context_widget.show()
 
             if item.context_change_allowed:


### PR DESCRIPTION
Sometimes you need to nest items and it's useful to be able to add extra context widgets even if the item isn't a top level item.