### PR TITLE
SG-16766 Fixes a bug when a UI isn't present

### DIFF
--- a/python/tk_multi_publish2/api/plugins/publish_plugin_instance.py
+++ b/python/tk_multi_publish2/api/plugins/publish_plugin_instance.py
@@ -154,7 +154,7 @@ class PublishPluginInstance(PluginInstanceBase):
             )
             return {"accepted": False}
         finally:
-            if not sgtk.platform.current_engine().has_ui:
+            if sgtk.platform.current_engine().has_ui:
                 from sgtk.platform.qt import QtCore
 
                 QtCore.QCoreApplication.processEvents()


### PR DESCRIPTION
Fixes a bug where we accidentally tried to do UI specific logic only when a UI wasn't present.
So this reverses that logic to only do it when a UI is present.

I've also searched the code for other uses of `has_ui` as this is the second case of this, and all other ones appear to be correct.