### PR TITLE
Fix PyQt QIcon

### DIFF
--- a/python/tk_multi_publish2/progress/progress_handler.py
+++ b/python/tk_multi_publish2/progress/progress_handler.py
@@ -192,7 +192,7 @@ class ProgressHandler(object):
         item.setText(0, message)
 
         if icon:
-            item.setIcon(0, icon)
+            item.setIcon(0, QtGui.QIcon(icon))
 
         if self._logging_parent_item:
             self._logging_parent_item.addChild(item)
@@ -278,11 +278,11 @@ class ProgressHandler(object):
             self._logging_parent_item.addChild(item)
 
         if icon:
-            item.setIcon(0, icon)
+            item.setIcon(0, QtGui.QIcon(icon))
             self._icon_label.setPixmap(icon)
         elif self._current_phase:
             std_icon = self._icon_lookup[self._current_phase]
-            item.setIcon(0, std_icon)
+            item.setIcon(0, QtGui.QIcon(std_icon))
             self._icon_label.setPixmap(std_icon)
 
         self._progress_details.log_tree.setCurrentItem(item)

--- a/python/tk_multi_publish2/publish_tree_widget/tree_node_item.py
+++ b/python/tk_multi_publish2/publish_tree_widget/tree_node_item.py
@@ -183,7 +183,7 @@ class TreeNodeItem(TreeNodeBase):
         else:
             icon = self._expanded_icon
 
-        self._embedded_widget.expand_indicator.setIcon(icon)
+        self._embedded_widget.expand_indicator.setIcon(QtGui.QIcon(icon))
 
     def _check_expand_state(self):
         """
@@ -196,7 +196,7 @@ class TreeNodeItem(TreeNodeBase):
         else:
             icon = self._collapsed_icon
 
-        self._embedded_widget.expand_indicator.setIcon(icon)
+        self._embedded_widget.expand_indicator.setIcon(QtGui.QIcon(icon))
 
 
 class TopLevelTreeNodeItem(TreeNodeItem):


### PR DESCRIPTION
Use explicit QIcon for Katana/PyQt, from [v2.3.4+wwfx.1.0.0](https://github.com/wwfxuk/tk-multi-publish2/tree/v2.3.4%2Bwwfx.1.0.0)

### Fixes

- Icons for Katana/PyQt