### PR TITLE
Inherit descriptions

### DIFF
--- a/python/tk_multi_publish2/api/item.py
+++ b/python/tk_multi_publish2/api/item.py
@@ -93,6 +93,7 @@ class PublishItem(object):
         "_thumbnail_pixmap",
         "_type_display",
         "_type_spec",
+        "_inherit_description",
     ]
 
     @classmethod
@@ -124,6 +125,7 @@ class PublishItem(object):
         new_item._thumbnail_enabled = item_dict["thumbnail_enabled"]
         new_item._thumbnail_explicit = item_dict["thumbnail_explicit"]
         new_item._thumbnail_path = item_dict["thumbnail_path"]
+        new_item._inherit_description = item_dict["inherit_description"]
 
         # create the children of this item
         for child_dict in item_dict["children"]:
@@ -200,6 +202,7 @@ class PublishItem(object):
         self._thumbnail_pixmap = None
         self._type_display = type_display
         self._type_spec = type_spec
+        self._inherit_description = True
 
     def __del__(self):
         """
@@ -256,6 +259,7 @@ class PublishItem(object):
             "thumbnail_path": self._thumbnail_path,
             "type_display": self.type_display,
             "type_spec": self.type_spec,
+            "inherit_description": self.inherit_description
         }
 
     def __repr__(self):
@@ -637,6 +641,8 @@ class PublishItem(object):
         The description of the item if it has been explicitly set, ``None``
         otherwise.
         """
+        if self._inherit_description and self.parent:
+            return self.parent.description
         return self._description
 
     @description.setter
@@ -1010,6 +1016,20 @@ class PublishItem(object):
     def display_type(self, new_type_display):
         """DEPRECATED setter."""
         self.type_display = new_type_display
+
+    @property
+    def inherit_description(self):
+        """
+        Whether to inherit the description from this item's parent.
+
+        :rtype: :class:`bool`
+        """
+        return self._inherit_description
+
+    @inherit_description.setter
+    def inherit_description(self, inherit):
+        """Set the inheritance value for descriptions."""
+        self._inherit_description = inherit
 
     ############################################################################
     # internal methods

--- a/python/tk_multi_publish2/api/item.py
+++ b/python/tk_multi_publish2/api/item.py
@@ -259,7 +259,7 @@ class PublishItem(object):
             "thumbnail_path": self._thumbnail_path,
             "type_display": self.type_display,
             "type_spec": self.type_spec,
-            "inherit_description": self.inherit_description
+            "inherit_description": self.inherit_description,
         }
 
     def __repr__(self):

--- a/python/tk_multi_publish2/api/item.py
+++ b/python/tk_multi_publish2/api/item.py
@@ -642,7 +642,7 @@ class PublishItem(object):
         otherwise.
         """
         if self._inherit_description and self.parent:
-            return self.parent.description
+            return self.parent.description or self._description
         return self._description
 
     @description.setter

--- a/python/tk_multi_publish2/dialog.py
+++ b/python/tk_multi_publish2/dialog.py
@@ -551,13 +551,13 @@ class AppDialog(QtGui.QWidget):
             # Set whether the descrition is to be inherited.
             # If the comment is empty, then it should inherit.
             # Also if the comment is empty, set self.ui.item_comments
-            if not comments:
+            if comments:
+                self._current_item.inherit_description = False
+            else:
                 self._current_item.inherit_description = True
                 self.ui.item_comments.blockSignals(True)
                 self.ui.item_comments.setPlainText(self._current_item.description)
                 self.ui.item_comments.blockSignals(False)
-            else:
-                self._current_item.inherit_description = False
 
         font = self.ui.item_comments.font()
         font.setItalic(self._current_item.inherit_description)

--- a/python/tk_multi_publish2/dialog.py
+++ b/python/tk_multi_publish2/dialog.py
@@ -137,7 +137,7 @@ class AppDialog(QtGui.QWidget):
         self.ui.items_tree.status_clicked.connect(self._on_publish_status_clicked)
 
         # when the description is updated
-        self.ui.item_comments.editing_finished.connect(self._on_item_comment_change)
+        self.ui.item_comments.textChanged.connect(self._on_item_comment_change)
 
         # selection in tree view
         self.ui.items_tree.itemSelectionChanged.connect(
@@ -553,7 +553,9 @@ class AppDialog(QtGui.QWidget):
             # Also if the comment is empty, set self.ui.item_comments
             if not comments:
                 self._current_item.inherit_description = True
+                self.ui.item_comments.blockSignals(True)
                 self.ui.item_comments.setPlainText(self._current_item.description)
+                self.ui.item_comments.blockSignals(False)
             else:
                 self._current_item.inherit_description = False
 
@@ -617,7 +619,9 @@ class AppDialog(QtGui.QWidget):
             self.ui.item_thumbnail.hide()
 
         self.ui.item_description_label.setText("Description")
+        self.ui.item_comments.blockSignals(True)
         self.ui.item_comments.setPlainText(item.description)
+        self.ui.item_comments.blockSignals(False)
         font = self.ui.item_comments.font()
         font.setItalic(item.inherit_description)
         self.ui.item_comments.setFont(font)

--- a/python/tk_multi_publish2/publish_description_edit.py
+++ b/python/tk_multi_publish2/publish_description_edit.py
@@ -19,6 +19,8 @@ class PublishDescriptionEdit(QtGui.QPlainTextEdit):
     Widget that holds the summary description
     """
 
+    editing_finished = QtCore.Signal()
+
     def __init__(self, parent):
         """
         Constructor
@@ -35,8 +37,8 @@ class PublishDescriptionEdit(QtGui.QPlainTextEdit):
 
     def paintEvent(self, paint_event):
         """
-       Paints the line plain text editor and adds a placeholder on bottom right corner when multiple values are detected.
-       """
+        Paints the line plain text editor and adds a placeholder on bottom right corner when multiple values are detected.
+        """
 
         # If the box does not have focus, draw <multiple values> placeholder when self._show_placeholder is true, even if the widget has text
         if not self.hasFocus() and self._show_placeholder == True:
@@ -55,3 +57,17 @@ class PublishDescriptionEdit(QtGui.QPlainTextEdit):
 
         else:
             QtGui.QPlainTextEdit.paintEvent(self, paint_event)
+
+    def keyPressEvent(self, event):
+        """
+        Make return and enter keys emit the editing finished command.
+
+        :param event: A :class:`QtGui.QKeyEvent' event.
+        """
+        if (
+            event.key() in (QtCore.Qt.Key_Return, QtCore.Qt.Key_Enter)
+            and event.modifiers() == QtCore.Qt.NoModifier
+        ):
+            self.editing_finished.emit()
+            return
+        super(PublishDescriptionEdit, self).keyPressEvent(event)

--- a/python/tk_multi_publish2/publish_description_edit.py
+++ b/python/tk_multi_publish2/publish_description_edit.py
@@ -19,8 +19,6 @@ class PublishDescriptionEdit(QtGui.QPlainTextEdit):
     Widget that holds the summary description
     """
 
-    editing_finished = QtCore.Signal()
-
     def __init__(self, parent):
         """
         Constructor
@@ -57,17 +55,3 @@ class PublishDescriptionEdit(QtGui.QPlainTextEdit):
 
         else:
             QtGui.QPlainTextEdit.paintEvent(self, paint_event)
-
-    def keyPressEvent(self, event):
-        """
-        Make return and enter keys emit the editing finished command.
-
-        :param event: A :class:`QtGui.QKeyEvent' event.
-        """
-        if (
-            event.key() in (QtCore.Qt.Key_Return, QtCore.Qt.Key_Enter)
-            and event.modifiers() == QtCore.Qt.NoModifier
-        ):
-            self.editing_finished.emit()
-            return
-        super(PublishDescriptionEdit, self).keyPressEvent(event)


### PR DESCRIPTION
From our [v2.4.1+wwfx.1.1.0] and [v2.4.1+wwfx.1.1.1] releases. See also https://github.com/wwfxuk/tk-multi-publish2/pull/9 and https://github.com/wwfxuk/tk-multi-publish2/pull/10

### Added

- `PublishItem.inherit_description` property,  which use the parent's description if `True`

### Changed

- Description box in publish window now displays inherited comments in italic, on child items.
- `AppDialog._on_item_comment_change` now sets the `inherit_description` property when a description is changed. Also will repopulate the text with the parent's description if the user clears the entry.
- `*args` [style logger message formatting](https://docs.python.org/3/library/logging.html?highlight=args#logging.Logger.debug)

### Fixed

- `PublishDescriptionEdit.paintEvent()` docstrings indentation


[v2.4.1+wwfx.1.1.1]: https://github.com/wwfxuk/tk-multi-publish2/tree/v2.4.1+wwfx.1.1.1
[v2.4.1+wwfx.1.1.0]: https://github.com/wwfxuk/tk-multi-publish2/tree/v2.4.1+wwfx.1.1.0