### PR TITLE
Expose the PublishItem when setting the ui settings of the custom widget

### DIFF
--- a/python/tk_multi_publish2/api/plugins/publish_plugin_instance.py
+++ b/python/tk_multi_publish2/api/plugins/publish_plugin_instance.py
@@ -242,7 +242,7 @@ class PublishPluginInstance(PluginInstanceBase):
         with self._handle_plugin_error(None, "Error reading settings from UI: %s"):
             return self._hook_instance.get_ui_settings(parent)
 
-    def run_set_ui_settings(self, parent, settings):
+    def run_set_ui_settings(self, parent, settings, items):
         """
         Provides a list of settings from the custom UI. It is the responsibility of the UI
         handle different values for the same setting.
@@ -252,6 +252,7 @@ class PublishPluginInstance(PluginInstanceBase):
         :param parent: Parent widget
         :type parent: :class:`QtGui.QWidget`
         :param settings: List of dictionary of settings as python literals.
+        :param items: List of :class:`PublishItem`.
         """
 
         # nothing to do if running without a UI
@@ -259,7 +260,11 @@ class PublishPluginInstance(PluginInstanceBase):
             return None
 
         with self._handle_plugin_error(None, "Error writing settings to UI: %s"):
-            self._hook_instance.set_ui_settings(parent, settings)
+            try:
+                self._hook_instance.set_ui_settings(parent, settings, items)
+            except TypeError as e:
+                # for backward compatibility, we need to run the hook with the old signature
+                self._hook_instance.set_ui_settings(parent, settings)
 
     @contextmanager
     def _handle_plugin_error(self, success_msg, error_msg):

--- a/python/tk_multi_publish2/base_hooks/publish_plugin.py
+++ b/python/tk_multi_publish2/base_hooks/publish_plugin.py
@@ -480,7 +480,7 @@ class PublishPlugin(HookBaseClass):
         # custom UI to show up in the app
         return {}
 
-    def set_ui_settings(self, widget, settings):
+    def set_ui_settings(self, widget, settings, items):
         """
         Allows the custom UI to populate its fields with the settings from the
         currently selected tasks.
@@ -518,6 +518,7 @@ class PublishPlugin(HookBaseClass):
         :param widget: The widget that was created by `create_settings_widget`
         :param settings: a list of dictionaries of settings for each selected
             task.
+        :param items: a list of :class:`PublishItem` for each selected task.
         """
 
         # the default implementation does not show any editable widgets, so this

--- a/python/tk_multi_publish2/dialog.py
+++ b/python/tk_multi_publish2/dialog.py
@@ -1605,7 +1605,9 @@ class _TaskSelection(object):
         :param settings: List of settings for all tasks.
         """
         if self._items:
-            self._items[0].plugin.run_set_ui_settings(widget, settings)
+            # Parse the list of items to retrieve the PublishItem instance associated to each selected task
+            item_list = [i.item for i in self._items]
+            self._items[0].plugin.run_set_ui_settings(widget, settings, item_list)
 
     def __iter__(self):
         """


### PR DESCRIPTION
By doing this, we can access the item context and its properties and improve the widget behavior (for example, customize the UI according to the selected item context)


![add_item_to_publisher_widget](https://user-images.githubusercontent.com/38566472/81327468-97d6f880-909b-11ea-9bb7-4bd558f151fc.gif)
