### PR TITLE
SG-12136 Fixes Task and Item checkbox GUI state updates.

### DIFF
--- a/python/tk_multi_publish2/publish_tree_widget/tree_node_item.py
+++ b/python/tk_multi_publish2/publish_tree_widget/tree_node_item.py
@@ -57,6 +57,14 @@ class TreeNodeItem(TreeNodeBase):
 
         return widget
 
+    def set_check_state(self, state):
+        """
+        Called when the check state of the item changes.
+        """
+        # Ensure that the item's check state matches the GUIs.
+        self._item.checked = state != QtCore.Qt.Unchecked
+        super(TreeNodeItem, self).set_check_state(state)
+
     def __repr__(self):
         return "<TreeNodeItem %s>" % str(self)
 

--- a/python/tk_multi_publish2/publish_tree_widget/tree_node_task.py
+++ b/python/tk_multi_publish2/publish_tree_widget/tree_node_task.py
@@ -64,6 +64,9 @@ class TreeNodeTask(TreeNodeBase):
         """
         Called by child item when checkbox was ticked
         """
+        # Ensure that we set the task to match the UI state
+        self._task.active = state != QtCore.Qt.Unchecked
+
         if apply_to_all_plugins:
             # do it for all of the items
             self.treeWidget().set_check_state_for_all_plugins(self._task.plugin, state)


### PR DESCRIPTION
Fixes an issue where when the state of an item or a task in the Publish UI is changed by the user, the Task or Item API object instances weren't updated to reflect this change.

We have another PR here #105, but this PR takes a different approach, and also fixes the task state as well.