### PR TITLE
SG-10067 Passes selected publish tasks associated items to set/create UI methods.

### DIFF
--- a/python/tk_multi_publish2/api/plugins/publish_plugin_instance.py
+++ b/python/tk_multi_publish2/api/plugins/publish_plugin_instance.py
@@ -270,7 +270,7 @@ class PublishPluginInstance(PluginInstanceBase):
                 self._hook_instance.set_ui_settings(parent, settings, items)
             except TypeError:
                 # Items is a newer attribute, which an older version of the hook
-                # might not implement, so fallback to passing just the parent.
+                # might not implement, so fallback to passing just the parent and settings.
                 self._hook_instance.set_ui_settings(parent, settings)
 
     @contextmanager

--- a/python/tk_multi_publish2/api/plugins/publish_plugin_instance.py
+++ b/python/tk_multi_publish2/api/plugins/publish_plugin_instance.py
@@ -208,7 +208,7 @@ class PublishPluginInstance(PluginInstanceBase):
     ############################################################################
     # ui methods
 
-    def run_create_settings_widget(self, parent):
+    def run_create_settings_widget(self, parent, items):
         """
         Creates a custom widget to edit a plugin's settings.
 
@@ -216,6 +216,7 @@ class PublishPluginInstance(PluginInstanceBase):
 
         :param parent: Parent widget
         :type parent: :class:`QtGui.QWidget`
+        :param items: A list of PublishItems the selected tasks are parented to.
         """
 
         # nothing to do if running without a UI
@@ -223,7 +224,12 @@ class PublishPluginInstance(PluginInstanceBase):
             return None
 
         with self._handle_plugin_error(None, "Error laying out widgets: %s"):
-            return self._hook_instance.create_settings_widget(parent)
+            try:
+                return self._hook_instance.create_settings_widget(parent, items)
+            except TypeError:
+                # Items is a newer attribute, which an older version of the hook
+                # might not implement, so fallback to passing just the parent.
+                return self._hook_instance.create_settings_widget(parent)
 
     def run_get_ui_settings(self, parent):
         """
@@ -242,7 +248,7 @@ class PublishPluginInstance(PluginInstanceBase):
         with self._handle_plugin_error(None, "Error reading settings from UI: %s"):
             return self._hook_instance.get_ui_settings(parent)
 
-    def run_set_ui_settings(self, parent, settings):
+    def run_set_ui_settings(self, parent, settings, items):
         """
         Provides a list of settings from the custom UI. It is the responsibility of the UI
         handle different values for the same setting.
@@ -252,6 +258,7 @@ class PublishPluginInstance(PluginInstanceBase):
         :param parent: Parent widget
         :type parent: :class:`QtGui.QWidget`
         :param settings: List of dictionary of settings as python literals.
+        :param items: A list of PublishItems the selected tasks are parented to.
         """
 
         # nothing to do if running without a UI
@@ -259,7 +266,12 @@ class PublishPluginInstance(PluginInstanceBase):
             return None
 
         with self._handle_plugin_error(None, "Error writing settings to UI: %s"):
-            self._hook_instance.set_ui_settings(parent, settings)
+            try:
+                self._hook_instance.set_ui_settings(parent, settings, items)
+            except TypeError:
+                # Items is a newer attribute, which an older version of the hook
+                # might not implement, so fallback to passing just the parent.
+                self._hook_instance.set_ui_settings(parent, settings)
 
     @contextmanager
     def _handle_plugin_error(self, success_msg, error_msg):

--- a/python/tk_multi_publish2/api/plugins/publish_plugin_instance.py
+++ b/python/tk_multi_publish2/api/plugins/publish_plugin_instance.py
@@ -233,12 +233,12 @@ class PublishPluginInstance(PluginInstanceBase):
 
         with self._handle_plugin_error(None, "Error laying out widgets: %s"):
 
-            if "items" in getargspec(self._hook_instance.create_settings_widget):
-                self._hook_instance.create_settings_widget(parent, items)
+            if len(getargspec(self._hook_instance.create_settings_widget).args) == 3:
+                return self._hook_instance.create_settings_widget(parent, items)
             else:
                 # Items is a newer attribute, which an older version of the hook
                 # might not implement, so fallback to passing just the parent.
-                self._hook_instance.create_settings_widget(parent)
+                return self._hook_instance.create_settings_widget(parent)
 
     def run_get_ui_settings(self, parent, items):
         """
@@ -256,12 +256,12 @@ class PublishPluginInstance(PluginInstanceBase):
 
         with self._handle_plugin_error(None, "Error reading settings from UI: %s"):
 
-            if "items" in getargspec(self._hook_instance.get_ui_settings):
-                self._hook_instance.get_ui_settings(parent, items)
+            if len(getargspec(self._hook_instance.get_ui_settings).args) == 3:
+                return self._hook_instance.get_ui_settings(parent, items)
             else:
                 # Items is a newer attribute, which an older version of the hook
                 # might not implement, so fallback to passing just the parent.
-                self._hook_instance.get_ui_settings(parent)
+                return self._hook_instance.get_ui_settings(parent)
 
     def run_set_ui_settings(self, parent, settings, items):
         """
@@ -282,7 +282,7 @@ class PublishPluginInstance(PluginInstanceBase):
 
         with self._handle_plugin_error(None, "Error writing settings to UI: %s"):
 
-            if "items" in getargspec(self._hook_instance.set_ui_settings):
+            if len(getargspec(self._hook_instance.set_ui_settings).args) == 4:
                 self._hook_instance.set_ui_settings(parent, settings, items)
             else:
                 # Items is a newer attribute, which an older version of the hook

--- a/python/tk_multi_publish2/base_hooks/publish_plugin.py
+++ b/python/tk_multi_publish2/base_hooks/publish_plugin.py
@@ -415,7 +415,7 @@ class PublishPlugin(HookBaseClass):
     # allows clients to write their own publish plugins while deferring custom
     # UI settings implementations until needed.
 
-    def create_settings_widget(self, parent, items):
+    def create_settings_widget(self, parent, items=None):
         """
         Creates a Qt widget, for the supplied parent widget (a container widget
         on the right side of the publish UI).
@@ -450,7 +450,7 @@ class PublishPlugin(HookBaseClass):
         # return the description group box as the widget to display
         return description_group_box
 
-    def get_ui_settings(self, widget):
+    def get_ui_settings(self, widget, items=None):
         """
         Invoked by the Publisher when the selection changes. This method gathers the settings
         on the previously selected task, so that they can be later used to repopulate the
@@ -481,7 +481,7 @@ class PublishPlugin(HookBaseClass):
         # custom UI to show up in the app
         return {}
 
-    def set_ui_settings(self, widget, settings, items):
+    def set_ui_settings(self, widget, settings, items=None):
         """
         Allows the custom UI to populate its fields with the settings from the
         currently selected tasks.

--- a/python/tk_multi_publish2/base_hooks/publish_plugin.py
+++ b/python/tk_multi_publish2/base_hooks/publish_plugin.py
@@ -189,7 +189,7 @@ class PublishPlugin(HookBaseClass):
         parameter in the :meth:`accept`, :meth:`validate`, :meth:`publish`, and
         :meth:`finalize` methods.
 
-        The values also drive the custom UI defined by the plugin whick allows
+        The values also drive the custom UI defined by the plugin which allows
         artists to manipulate the settings at runtime. See the
         :meth:`create_settings_widget`, :meth:`set_ui_settings`, and
         :meth:`get_ui_settings` for additional information.
@@ -415,12 +415,13 @@ class PublishPlugin(HookBaseClass):
     # allows clients to write their own publish plugins while deferring custom
     # UI settings implementations until needed.
 
-    def create_settings_widget(self, parent):
+    def create_settings_widget(self, parent, items):
         """
         Creates a Qt widget, for the supplied parent widget (a container widget
         on the right side of the publish UI).
 
-        :param parent: The parent to use for the widget being created
+        :param parent: The parent to use for the widget being created.
+        :param items: A list of PublishItems the selected publish tasks are parented to.
         :return: A QtGui.QWidget or subclass that displays information about
             the plugin and/or editable widgets for modifying the plugin's
             settings.
@@ -480,7 +481,7 @@ class PublishPlugin(HookBaseClass):
         # custom UI to show up in the app
         return {}
 
-    def set_ui_settings(self, widget, settings):
+    def set_ui_settings(self, widget, settings, items):
         """
         Allows the custom UI to populate its fields with the settings from the
         currently selected tasks.
@@ -515,9 +516,10 @@ class PublishPlugin(HookBaseClass):
         there is more than one item in the list and the publisher will inform
         the user than only one task of that type can be edited at a time.
 
-        :param widget: The widget that was created by `create_settings_widget`
+        :param widget: The widget that was created by `create_settings_widget`.
         :param settings: a list of dictionaries of settings for each selected
             task.
+        :param items: A list of PublishItems the selected publish tasks are parented to.
         """
 
         # the default implementation does not show any editable widgets, so this

--- a/python/tk_multi_publish2/dialog.py
+++ b/python/tk_multi_publish2/dialog.py
@@ -443,7 +443,7 @@ class AppDialog(QtGui.QWidget):
         else:
             logger.debug("Building a custom ui for %s.", new_task_selection.plugin)
             widget = new_task_selection.plugin.run_create_settings_widget(
-                self.ui.task_settings_parent
+                self.ui.task_settings_parent, new_task_selection.get_task_items()
             )
             self.ui.task_settings.widget = widget
 
@@ -1743,8 +1743,18 @@ class _TaskSelection(object):
         :param widget: Custom UI's widget.
         :param settings: List of settings for all tasks.
         """
+
+        # Get the publish items associated with the selected tasks.
+        publish_items = self.get_task_items()
         if self._items:
-            self._items[0].plugin.run_set_ui_settings(widget, settings)
+            self._items[0].plugin.run_set_ui_settings(widget, settings, publish_items)
+
+    def get_task_items(self):
+        """
+        Gets a list of items that the selected tasks are parented too.
+        :return: list of PublishItems.
+        """
+        return [task.item for task in self._items]
 
     def __iter__(self):
         """

--- a/python/tk_multi_publish2/dialog.py
+++ b/python/tk_multi_publish2/dialog.py
@@ -470,7 +470,7 @@ class AppDialog(QtGui.QWidget):
 
         # Update the values in all the tasks.
         for task in selected_tasks:
-            # The settings returned by the UI are actual value, not Settings objects, so apply each
+            # The settings returned by the UI are actual values, not Settings objects, so apply each
             # value returned on the appropriate settings object.
             for k, v in settings.items():
                 task.settings[k].value = v

--- a/python/tk_multi_publish2/dialog.py
+++ b/python/tk_multi_publish2/dialog.py
@@ -1732,7 +1732,9 @@ class _TaskSelection(object):
         :returns: Dictionary of settings as regular Python literals.
         """
         if self._items:
-            return self._items[0].plugin.run_get_ui_settings(widget)
+            # Get the publish items associated with the selected tasks.
+            publish_items = self.get_task_items()
+            return self._items[0].plugin.run_get_ui_settings(widget, publish_items)
         else:
             return {}
 
@@ -1743,10 +1745,9 @@ class _TaskSelection(object):
         :param widget: Custom UI's widget.
         :param settings: List of settings for all tasks.
         """
-
-        # Get the publish items associated with the selected tasks.
-        publish_items = self.get_task_items()
         if self._items:
+            # Get the publish items associated with the selected tasks.
+            publish_items = self.get_task_items()
             self._items[0].plugin.run_set_ui_settings(widget, settings, publish_items)
 
     def get_task_items(self):

--- a/tests/fixtures/config/hooks/plugin_with_ui.py
+++ b/tests/fixtures/config/hooks/plugin_with_ui.py
@@ -229,7 +229,7 @@ class PluginWithUi(HookBaseClass):
             ),
         )
 
-    def get_ui_settings(self, controller):
+    def get_ui_settings(self, controller, items):
         """
         Returns the modified settings.
         """

--- a/tests/fixtures/config/hooks/plugin_with_ui.py
+++ b/tests/fixtures/config/hooks/plugin_with_ui.py
@@ -214,7 +214,7 @@ class PluginWithUi(HookBaseClass):
     Plugin for creating generic publishes in Shotgun
     """
 
-    def create_settings_widget(self, parent):
+    def create_settings_widget(self, parent, items):
         """
         Creates a QT widget, parented below the given parent object, to
         provide viewing and editing capabilities for the given settings.
@@ -224,7 +224,9 @@ class PluginWithUi(HookBaseClass):
         """
         return CustomWidgetController(
             parent,
-            description_widget=super(PluginWithUi, self).create_settings_widget(parent),
+            description_widget=super(PluginWithUi, self).create_settings_widget(
+                parent, items
+            ),
         )
 
     def get_ui_settings(self, controller):
@@ -257,7 +259,7 @@ class PluginWithUi(HookBaseClass):
             is False
         )
 
-    def set_ui_settings(self, controller, tasks_settings):
+    def set_ui_settings(self, controller, tasks_settings, items):
         """
         Updates the UI with the list of settings.
         """

--- a/tests/test_publish_plugin_instance.py
+++ b/tests/test_publish_plugin_instance.py
@@ -145,3 +145,54 @@ class TestPublishPluginInstance(PublishApiTestBase):
         handler.keyword = "Error running accept for"
         self.assertEqual(ppi.run_accept(None), {"accepted": True})
         self.assertFalse(handler.found)
+
+    # The following four methods are mock methods for the three UI customization methods.
+    # get_ui_settings
+    # set_ui_settings
+    # create_settings_widget
+    # We're not using proper return values, as we are only testing that the API handles
+    # passing the correct amount of arguments.
+
+    def _mock_get_create_w_items(self, parent, items):
+        return "passed"
+
+    def _mock_get_create_wo_items(self, parent):
+        return "passed"
+
+    def _mock_set_settings_w_items(self, parent, settings, items):
+        pass
+
+    def _mock_set_settings_wo_items(self, parent, settings):
+        pass
+
+    @mock_publish_plugin_instance_hook_creation
+    def test_plugin_ui_methods(self, create_hook_instance):
+        """
+        Ensure that the custom UI methods receive the correct number of arguments.
+        """
+
+        # Create hook instances for the UI methods that accept the items arg
+        create_hook_instance.return_value = MagicMock(
+            create_settings_widget=self._mock_get_create_w_items,
+            get_ui_settings=self._mock_get_create_w_items,
+            set_ui_settings=self._mock_set_settings_w_items,
+        )
+        ppi_w_items = self.PublishPluginInstance("test hook", None, {}, logger)
+
+        create_hook_instance.return_value = MagicMock(
+            create_settings_widget=self._mock_get_create_wo_items,
+            get_ui_settings=self._mock_get_create_wo_items,
+            set_ui_settings=self._mock_set_settings_wo_items,
+        )
+        ppi_wo_items = self.PublishPluginInstance("test hook", None, {}, logger)
+
+        for ppi in [ppi_w_items, ppi_wo_items]:
+
+            widget = ppi.run_create_settings_widget(None, [])
+            self.assertEqual(widget, "passed")
+
+            settings = ppi.run_get_ui_settings(None, [])
+            self.assertEqual(settings, "passed")
+
+            # we're just checking this doesn't error, as it doesn't return anything
+            ppi.run_set_ui_settings(None, [], [])

--- a/tests/test_publish_plugin_instance.py
+++ b/tests/test_publish_plugin_instance.py
@@ -169,6 +169,9 @@ class TestPublishPluginInstance(PublishApiTestBase):
     def test_plugin_ui_methods(self, create_hook_instance):
         """
         Ensure that the custom UI methods receive the correct number of arguments.
+        Previously the custom ui Methods didn't get passed items, so this test makes sure
+        that the API can handle calling the hooks when they either implement or don't
+        implement the items.
         """
 
         # Create hook instances for the UI methods that accept the items arg

--- a/tests/test_publish_plugin_instance.py
+++ b/tests/test_publish_plugin_instance.py
@@ -153,6 +153,8 @@ class TestPublishPluginInstance(PublishApiTestBase):
     # We're not using proper return values, as we are only testing that the API handles
     # passing the correct amount of arguments.
 
+    # Both create and get methods accept the same args, so we don't need
+    # separate testing methods.
     def _mock_get_create_w_items(self, parent, items):
         return "passed"
 
@@ -175,6 +177,9 @@ class TestPublishPluginInstance(PublishApiTestBase):
         """
 
         # Create hook instances for the UI methods that accept the items arg
+        # We are not using lambdas for these, since the API checks for the
+        # number of arguments on the method, and there wouldn't be a `self`
+        # arg with a lambda.
         create_hook_instance.return_value = MagicMock(
             create_settings_widget=self._mock_get_create_w_items,
             get_ui_settings=self._mock_get_create_w_items,


### PR DESCRIPTION
This passes a list of `PublishItem`s associated with the selected publish tasks, through to the `create_settings_widget()` and `set_ui_settings()` methods, to allow users to customize the UI based upon the item details.

I opted not to pass the items through to the `get_ui_settings` method as I didn't really see a use case for that, but it could be easily added as well.