### PR TITLE
[SHOT-3575] Fix Qt style for light themed DCCs

### DIFF
--- a/style.qss
+++ b/style.qss
@@ -27,7 +27,7 @@ QWidget {
     font-style: Regular;
 }
 
-/* need this to kick QT into 'style mode' for labels otherwise things are not formatted correctly */
+/* Need this to kick QT into 'style mode' for labels otherwise things are not formatted correctly */
 QLabel {
     margin-top: 1px;
 }
@@ -326,7 +326,6 @@ ProgressDetailsWidget #log_tree::item {
 
 #progress_bar {
     border: none;
-    background-color: none;
     margin: 3px;
 }
 


### PR DESCRIPTION
Remove publisher app style to set the progress bar background colour to be transparent.

This is for DCCs that have a different style theme than Toolkit's dark theme. If the progress bar background colour is transparent, it will show the widget behind it, in this case it will be the dialog window that inherits the QApplication's palette Window attribute. This only works for DCCs that have a theme that is consistent with Toolkit.

For example, SketchBook has a light theme and the progress bar will show up as white, instead of the desired darker grey colour.

Tested with Maya, and this change has no effect on the progress bar colour.