### PR TITLE
[SKB-2333] Prompt user to save work  before opening publish dialog

### DIFF
--- a/app.py
+++ b/app.py
@@ -44,6 +44,8 @@ class MultiPublish2(sgtk.platform.Application):
         # replace all non alphanumeric characters by '_'
         command_name = re.sub(r"[^0-9a-zA-Z]+", "_", command_name)
 
+        self.modal = self.get_setting("modal")
+
         # register command
         cb = lambda: tk_multi_publish2.show_dialog(self)
         menu_caption = "%s..." % display_name

--- a/app.py
+++ b/app.py
@@ -20,6 +20,8 @@ class MultiPublish2(sgtk.platform.Application):
     top-level publish2 interface.
     """
 
+    CONFIG_PRE_PUBLISH_HOOK_PATH = "pre_publish"
+
     def init_app(self):
         """
         Called as the application is being initialized
@@ -45,7 +47,9 @@ class MultiPublish2(sgtk.platform.Application):
         command_name = re.sub(r"[^0-9a-zA-Z]+", "_", command_name)
 
         self.modal = self.get_setting("modal")
-        self.require_save = self.engine.get_setting("require_save_before_publish")
+
+        pre_publish_hook_path = self.get_setting(self.CONFIG_PRE_PUBLISH_HOOK_PATH)
+        self.pre_publish_hook = self.create_hook_instance(pre_publish_hook_path)
 
         # register command
         cb = lambda: tk_multi_publish2.show_dialog(self)

--- a/app.py
+++ b/app.py
@@ -45,6 +45,7 @@ class MultiPublish2(sgtk.platform.Application):
         command_name = re.sub(r"[^0-9a-zA-Z]+", "_", command_name)
 
         self.modal = self.get_setting("modal")
+        self.require_save = self.engine.get_setting("require_save_before_publish")
 
         # register command
         cb = lambda: tk_multi_publish2.show_dialog(self)

--- a/hooks/pre_publish.py
+++ b/hooks/pre_publish.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2018 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import sgtk
+
+HookBaseClass = sgtk.get_hook_baseclass()
+
+
+class PrePublishHook(HookBaseClass):
+    """
+    This hook defines logic to be executed before showing the publish
+    dialog. There may be conditions that need to be checked before allowing
+    the user to proceed to publishing.
+    """
+
+    def validate(self):
+        """
+        Returns True if the user can proceed to publish. Override thsi hook
+        method to execute any custom validation steps.
+        """
+
+        return True

--- a/info.yml
+++ b/info.yml
@@ -110,6 +110,13 @@ configuration:
            buttons to select files or folders. When false, the feature basically
            disable the user ability to add anything to the project."
 
+    modal:
+        type: bool
+        default_value: false
+        description:
+          "If true the app dialog will be opened in modal window mode, else if
+           false (default) the dialog will be opened in non-modal window mode."
+
 # the Shotgun fields that this app needs in order to operate correctly
 requires_shotgun_fields:
 

--- a/info.yml
+++ b/info.yml
@@ -117,6 +117,7 @@ configuration:
           "If true the app dialog will be opened in modal window mode, else if
            false (default) the dialog will be opened in non-modal window mode."
 
+
 # the Shotgun fields that this app needs in order to operate correctly
 requires_shotgun_fields:
 

--- a/info.yml
+++ b/info.yml
@@ -48,6 +48,14 @@ configuration:
            identification, publish display name, image sequence paths, etc."
         default_value: "{self}/path_info.py"
 
+    pre_publish:
+        type: hook
+        description:
+          "This hook defines logic to be executed before showing the publish
+          dialog. There may be conditions that need to be checked before allowing
+          the user to proceed to publishing."
+        default_value: "{self}/pre_publish.py"
+
     task_required:
         type: bool
         description:

--- a/python/tk_multi_publish2/__init__.py
+++ b/python/tk_multi_publish2/__init__.py
@@ -31,18 +31,28 @@ def show_dialog(app):
     # check for unsaved work and prompt the user if necessary
     # do not allow the user to publish, until their work has been saved to Shotgun
     show = True
-    if not app.engine.current_work_has_path():
-        answer = QtGui.QMessageBox.question(
-            None,
-            "Save Work",
-            "Do you want to save your work to continue to publish?",
-            defaultButton=QtGui.QMessageBox.Yes,
-        )
+    if app.require_save:
+        try:
+            if not app.engine.current_session_path():
+                answer = QtGui.QMessageBox.question(
+                    None,
+                    "Save Work",
+                    "Do you want to save your work to continue to publish?",
+                    defaultButton=QtGui.QMessageBox.Yes,
+                )
 
-        if answer == QtGui.QMessageBox.Yes:
-            app.engine.show_save_dialog()
-            show = app.engine.current_work_has_path()
-        else:
+                if answer == QtGui.QMessageBox.Yes:
+                    app.engine.show_save_dialog()
+                    show = app.engine.current_session_path()
+                else:
+                    show = False
+
+        except AttributeError as error:
+            error_msg = "Error: '%s'" % error
+            app.logger.error(error_msg)
+            QtGui.QMessageBox.critical(
+                QtGui.QApplication.activeWindow(), "File Save Error", error_msg
+            )
             show = False
 
     if show:


### PR DESCRIPTION
The current workflow for publishing when file has not been saved yet:

1. Open publish dialog and plugins are accepted -- may yield warning message in logs that file requires saving first
2. On validate or publish, an error is reported if file has not yet been saved. In some engines, a `Save As` button appears next to the error in the publish log UI
3. User clicks `Save As` to save file and then they can continue to publish

We're proposing to improve this workflow:

1. Before opening the publish dialog, run a pre-publish hook to determine if user can proceed to publishing or not
2. Default to Yes the user can proceed. Engine's may define custom pre-publish hook logic.

Also, for SketchBook we want the option to open the publish dialog as a modal window -- so we've added a settings option `modal` that will be used to show the dialog in modal or not. Default will not be modal.

See use case example in tk-sketchbook: https://github.com/shotgunsoftware/tk-sketchbook/pull/40