### PR TITLE
Bug fix: Only hide the window if Thumbnail is not part of the main window

### DIFF
--- a/python/tk_multi_publish2/thumbnail.py
+++ b/python/tk_multi_publish2/thumbnail.py
@@ -107,11 +107,20 @@ class Thumbnail(QtGui.QLabel):
         """
         self._bundle.log_debug("Prompting for screenshot...")
 
-        self.window().hide()
+        # Hide the window containing this Thumbnail, unless it is Qt's QMainWindow which
+        # has the content to be screen captured.
+        window = self.window()
+        if isinstance(window, QtGui.QMainWindow):
+            hide = False
+        else:
+            hide = True
+            window.hide()
+
         try:
             pixmap = screen_grab.ScreenGrabber.screen_capture()
         finally:
-            self.window().show()
+            if hide:
+                self.window().show()
 
         if pixmap:
             self._bundle.log_debug(


### PR DESCRIPTION
An issue was found when docking the tk-multi-publish2 app dialog:
If the tk-multi-publish2 dialog is docked and a Thumbnail screen capture is triggered, it will hide the QMainWindow which has the content that the user will want to screen capture.

**Proposed solution**:
Only hide the window if the Thumbnail widget is not in the main window (e.g. it will only hide if it is in a separate dialog window from the main window). This assumes that the content to screen capture is always the QMainWindow -- is that accurate to assume? If not, we may want to change the condition to check if the Thumbnail is a QDockWidget. 

This has been tested by ACD QA:  https://jira.autodesk.com/browse/SHOT-3616?filter=136544