### PR TITLE
Remove ChecksState prefix for PyQt

### DIFF
--- a/python/tk_multi_publish2/publish_tree_widget/custom_widget_item.py
+++ b/python/tk_multi_publish2/publish_tree_widget/custom_widget_item.py
@@ -63,10 +63,10 @@ class CustomTreeWidgetItem(CustomTreeWidgetBase):
         """
         # Qt tri-state logic is a little odd. The default behaviour is to go from unchecked
         # to partially checked. We want it to go from unchecked to checked
-        if self.ui.checkbox.checkState() == QtCore.Qt.CheckState.Checked:
-            next_state = QtCore.Qt.CheckState.Unchecked
+        if self.ui.checkbox.checkState() == QtCore.Qt.Checked:
+            next_state = QtCore.Qt.Unchecked
         else:
-            next_state = QtCore.Qt.CheckState.Checked
+            next_state = QtCore.Qt.Checked
         self.ui.checkbox.setCheckState(next_state)
         self._tree_node.set_check_state(next_state)
 


### PR DESCRIPTION
From internal relase: [v2.5.4+wwfx.1.0.2](https://github.com/wwfxuk/tk-multi-publish2/releases/tag/v2.5.4+wwfx.1.0.2)

### Fixed

- `Qt.CheckState` incompatibility with `PyQt*`