### PR TITLE
SG-21329: Incorporates changes from client PR #99

### DIFF
--- a/python/tk_multi_publish2/api/manager.py
+++ b/python/tk_multi_publish2/api/manager.py
@@ -540,9 +540,9 @@ class PublishManager(object):
                 # current app instance.
                 for settings in context_settings:
                     if settings.get("app_instance") == self._bundle.instance_name:
-                        app_settings = settings
+                        app_settings = settings.get("settings")
             elif len(context_settings) == 1:
-                app_settings = context_settings[0]["settings"]
+                app_settings = context_settings[0].get("settings")
 
             if app_settings:
                 plugin_settings = app_settings[self.CONFIG_PLUGIN_DEFINITIONS]


### PR DESCRIPTION
One extra bit of cleanup was also done, just for consistency. The bug crops up when there are multiple instances of the publish2 app in the same engine/environment, and when the publish context is different than the parent bundle context. Note that I did not reproduce the specific error raised, but I did confirm that the bug existed by inspecting the structure of the data returned by `sgtk.platform.engine.find_app_settings` along with the obvious difference in logic between lines 543 and 545, which obviously shouldn't be different considering they're indexing into the same data structure as one another.