### PR TITLE
[Fix] Item icon: detect if we can use QPixmap if current_engine has ui

### DIFF
--- a/python/tk_multi_publish2/api/item.py
+++ b/python/tk_multi_publish2/api/item.py
@@ -37,6 +37,11 @@ def _is_qt_pixmap_usable():
     if _qt_pixmap_is_usable is not None:
         return _qt_pixmap_is_usable
 
+    # Check first that current engine has UI
+    if not sgtk.platform.current_engine().has_ui:
+        _qt_pixmap_is_usable = False
+        return _qt_pixmap_is_usable
+
     try:
         # We can fail importing if the engine doesn't even support Qt.
         from sgtk.platform.qt import QtGui

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -416,16 +416,17 @@ class TestQtPixmapAvailability(PublishApiTestBase):
         self._reset_pixmap_flag()
         self.assertTrue(self.api.item._is_qt_pixmap_usable())
 
-    def test_missing_qtgui(self):
+    def test_missing_engine_ui(self):
         """
-        Ensures a missing QApplication will not support QtPixmap usage.
+        Ensures an engine without UI will not support QtPixmap usage.
         """
-        QtGui = sgtk.platform.qt.QtGui
-        del sgtk.platform.qt.QtGui
-        self.assertFalse(self.api.item._is_qt_pixmap_usable())
-        self._reset_pixmap_flag()
+        with patch.object(
+            sgtk.platform.qt.QtGui.QApplication, "instance", return_value=None
+        ):
+            self.assertFalse(sgtk.platform.current_engine().has_ui)
+            self.assertFalse(self.api.item._is_qt_pixmap_usable())
 
-        sgtk.platform.qt.QtGui = QtGui
+        self._reset_pixmap_flag()
         self.assertTrue(self.api.item._is_qt_pixmap_usable())
 
     def test_pixmap_methods(self):


### PR DESCRIPTION
## Context
When using tk-multi-publish2 API with nuke in terminal mode (non gui) a segfault happens.

Root cause is located while calling [PublishItem::_validate_image](https://github.com/shotgunsoftware/tk-multi-publish2/blob/fdd309df1f892c5223be9da2c58b0b13e3bffa26/python/tk_multi_publish2/api/item.py#L501).

This method is triggered for instance when calling [item.set_icon_path](https://github.com/shotgunsoftware/tk-multi-publish2/blob/a83e35dbf1a85eac7c3abd7e7f5509a42a8b8cf1/tests/test_tree.py#L158) in collector.

## QPixmap usability
In nuke, we can import `QtGui.QPixmap` and `QtGui.QApplication.instance()` is not None.

But actually we can't use QPixmap because it will trigger a segfault.

## Changes

### Logic
When checking if we can use QPixmap, verify also that current_engine has UI.

### Unit test
Change unit test `test_missing_qtgui` into `test_missing_engine_ui`.

Removing sgtk.platform.qt.QtGui from current environment could alter the engine state integrity

For instance in tk-shell, `engine.has_ui` would raise an `ImportError`.  
It shouldn't be happen since at engine startup, propert Qt checks are done, and engine is set properly.
- To be fully functional, this tests would need engine to be rebuilt after changing `QtGui` availability.
- Test instead if current engine has no UI. In that case we shouldn't be able to use `QPixmap`