### PR TITLE
SG-41994 Enable word wrap for long error messages

### DIFF
--- a/python/tk_multi_publish2/progress/ui/more_info_widget.py
+++ b/python/tk_multi_publish2/progress/ui/more_info_widget.py
@@ -28,6 +28,7 @@ class Ui_MoreInfoWidget(object):
         self.pixmap_label.setObjectName("pixmap_label")
         self.horizontalLayout.addWidget(self.pixmap_label)
         self.message_label = QtGui.QLabel(MoreInfoWidget)
+        self.message_label.setWordWrap(True)
         self.message_label.setObjectName("message_label")
         self.horizontalLayout.addWidget(self.message_label)
         self.horizontalLayout.setStretch(0, 1)

--- a/resources/more_info_widget.ui
+++ b/resources/more_info_widget.ui
@@ -46,6 +46,9 @@
        <property name="text">
         <string>More Info...</string>
        </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
       </widget>
      </item>
     </layout>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9294702/122099910-7867de80-ce0a-11eb-8296-22db1e5561c7.png)

### Changed

- Enabled `setWordWrap` so dialog with long error messages, i.e. multi-inheritance publish plugin hook paths, doesn't show as a very very wide window