### PR TITLE
fix broken collections import on python > 3.8

### DIFF
--- a/python/tk_multi_publish2/api/data.py
+++ b/python/tk_multi_publish2/api/data.py
@@ -8,14 +8,14 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-import collections
+from tank_vendor.six.moves import collections_abc
 import sgtk
 import copy
 
 logger = sgtk.platform.get_logger(__name__)
 
 
-class PublishData(collections.MutableMapping):
+class PublishData(collections_abc.MutableMapping):
     """
     A simple dictionary-like object for storing/serializing arbitrary publish
     data.


### PR DESCRIPTION
# Problem
_MutableMapping_ has been moved from _collections_ to [collections.abc](https://docs.python.org/3.7/library/collections.abc.html#module-collections.abc) since python > 3.8.
The problem raised in Blender 3.2, using python 3.10.2.

# Solution
Use six (from tank_vendor) to ensure the import across python versions.