### PR TITLE
SG-20925 Formalize the deprecation of python 2.6 support in toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![VFX Platform](https://img.shields.io/badge/vfxplatform-2020-yellow.svg)](http://www.vfxplatform.com/)
-[![Python 2.6 2.7 3.7](https://img.shields.io/badge/python-2.6%20%7C%202.7%20%7C%203.7-blue.svg)](https://www.python.org/)
+[![Python 2.7 3.7](https://img.shields.io/badge/python-2.7%20%7C%203.7-blue.svg)](https://www.python.org/)
 [![Reference Documentation](http://img.shields.io/badge/doc-reference-blue.svg)](http://developer.shotgridsoftware.com/tk-multi-publish2)
 [![Build Status](https://dev.azure.com/shotgun-ecosystem/Toolkit/_apis/build/status/shotgunsoftware.tk-multi-publish2?branchName=master)](https://dev.azure.com/shotgun-ecosystem/Toolkit/_build/latest?definitionId=41&branchName=master)
 [![codecov](https://codecov.io/gh/shotgunsoftware/tk-multi-publish2/branch/master/graph/badge.svg)](https://codecov.io/gh/shotgunsoftware/tk-multi-publish2)


### PR DESCRIPTION
This PR includes the actions to remove Python 2.6 support in toolkit:
        - Remove python 2.6 badges
        - Update setup.py to drop support for 2.6
        - Update the documentation and the developer.shotgunsoftware.com doc site