### PR TITLE
Added support for python 3.10

### DIFF
--- a/python/tk_multi_publish2/api/data.py
+++ b/python/tk_multi_publish2/api/data.py
@@ -8,14 +8,19 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
+import sys
 import collections
+if sys.version_info.major == 3 and sys.version_info.minor >= 10:
+
+    from collections.abc import MutableMapping
+else:
+    from collections import MutableMapping
 import sgtk
 import copy
 
 logger = sgtk.platform.get_logger(__name__)
 
-
-class PublishData(collections.MutableMapping):
+class PublishData(MutableMapping):
     """
     A simple dictionary-like object for storing/serializing arbitrary publish
     data.


### PR DESCRIPTION
pulling in this fix allows the publish tool to work in blender 3.3 i.e python 3.10