### PR TITLE
SG-25264 Prevent Nuke crash when the app is being used in terminal only mode (no ui)

### DIFF
--- a/python/tk_multi_publish2/api/item.py
+++ b/python/tk_multi_publish2/api/item.py
@@ -37,6 +37,11 @@ def _is_qt_pixmap_usable():
     if _qt_pixmap_is_usable is not None:
         return _qt_pixmap_is_usable
 
+    # Check first that current engine has UI
+    if not sgtk.platform.current_engine().has_ui:
+        _qt_pixmap_is_usable = False
+        return _qt_pixmap_is_usable
+
     try:
         # We can fail importing if the engine doesn't even support Qt.
         from sgtk.platform.qt import QtGui

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -416,16 +416,17 @@ class TestQtPixmapAvailability(PublishApiTestBase):
         self._reset_pixmap_flag()
         self.assertTrue(self.api.item._is_qt_pixmap_usable())
 
-    def test_missing_qtgui(self):
+    def test_missing_engine_ui(self):
         """
-        Ensures a missing QApplication will not support QtPixmap usage.
+        Ensures an engine without UI will not support QtPixmap usage.
         """
-        QtGui = sgtk.platform.qt.QtGui
-        del sgtk.platform.qt.QtGui
-        self.assertFalse(self.api.item._is_qt_pixmap_usable())
-        self._reset_pixmap_flag()
+        with patch.object(
+            sgtk.platform.qt.QtGui.QApplication, "instance", return_value=None
+        ):
+            self.assertFalse(sgtk.platform.current_engine().has_ui)
+            self.assertFalse(self.api.item._is_qt_pixmap_usable())
 
-        sgtk.platform.qt.QtGui = QtGui
+        self._reset_pixmap_flag()
         self.assertTrue(self.api.item._is_qt_pixmap_usable())
 
     def test_pixmap_methods(self):


### PR DESCRIPTION
This is a rebased version of #141.

It is not possible to merge #141 as-is unfortunately because:
- The branch is 18 months old
  - The branch it is based on does not work with the current SG version.
- The PR checks did not pass and I am unable to re-run them

The code change, after rebasing, works and fixes the original issue: it prevents Nuke from crashing when running in terminal-only mode.

Reproduced on both Nuke versions 12 and 14.