### PR TITLE
SG-20984 Check hidden tree items on Publish dialog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ nosetests.xml
 
 # Jetbrains
 .idea/
+
+# VSCode
+.vscode/

--- a/python/tk_multi_publish2/publish_tree_widget/custom_widget_task.py
+++ b/python/tk_multi_publish2/publish_tree_widget/custom_widget_task.py
@@ -58,7 +58,7 @@ class CustomTreeWidgetTask(CustomTreeWidgetBase):
             logger.debug("shift held. propagating check to all plugins.")
             self._tree_node.set_check_state(state, apply_to_all_plugins=True)
         else:
-            self._tree_node.set_check_state(state)
+            self._tree_node.set_check_state(state, apply_to_invisible_siblings=True)
 
     def _on_status_click(self):
         """

--- a/python/tk_multi_publish2/publish_tree_widget/publish_tree_widget.py
+++ b/python/tk_multi_publish2/publish_tree_widget/publish_tree_widget.py
@@ -488,7 +488,29 @@ class PublishTreeWidget(QtGui.QTreeWidget):
         def _check_r(parent):
             for child_index in range(parent.childCount()):
                 child = parent.child(child_index)
-                if isinstance(child, TreeNodeTask) and child.task.plugin == plugin:
+                if isinstance(child, TreeNodeTask) and (
+                    child.task.plugin == plugin or not child.task.visible
+                ):
+                    child.set_check_state(state)
+                _check_r(child)
+
+        root = self.invisibleRootItem()
+        _check_r(root)
+
+    def set_check_state_for_invisible_siblings(self, plugin, state):
+        """
+        Set the check state for all invisible items,
+        otherwise there's no way to check back them.
+
+        :param plugin: Plugin for which tasks should be manipulated
+        :param state: checkstate to set.
+        """
+        logger.debug("Setting state %d for invisible sibling %s" % (state, plugin))
+
+        def _check_r(parent):
+            for child_index in range(parent.childCount()):
+                child = parent.child(child_index)
+                if isinstance(child, TreeNodeTask) and not child.task.visible:
                     child.set_check_state(state)
                 _check_r(child)
 

--- a/python/tk_multi_publish2/publish_tree_widget/tree_node_task.py
+++ b/python/tk_multi_publish2/publish_tree_widget/tree_node_task.py
@@ -60,7 +60,9 @@ class TreeNodeTask(TreeNodeBase):
         widget.set_checkbox_value(self.data(0, self.CHECKBOX_ROLE))
         return widget
 
-    def set_check_state(self, state, apply_to_all_plugins=False):
+    def set_check_state(
+        self, state, apply_to_all_plugins=False, apply_to_invisible_siblings=False
+    ):
         """
         Called by child item when checkbox was ticked
         """
@@ -70,6 +72,12 @@ class TreeNodeTask(TreeNodeBase):
         if apply_to_all_plugins:
             # do it for all of the items
             self.treeWidget().set_check_state_for_all_plugins(self._task.plugin, state)
+        elif apply_to_invisible_siblings:
+            # set invisible siblings
+            self.treeWidget().set_check_state_for_invisible_siblings(
+                self._task.plugin, state
+            )
+            super(TreeNodeTask, self).set_check_state(state)
         else:
             # set just this one
             super(TreeNodeTask, self).set_check_state(state)


### PR DESCRIPTION
This PR addresses the issue where is impossible to check back on the hidden (`visibility: False`) publish plugins. When any plugin is checked ✅ , all invisible plugins are also checked under the hood.

### Changes
- Adds a new flag to invoke a method similar to `set_check_state_for_all_plugins` that walks the tree and activate invisible plugins.
- Updates .gitignore with vscode directory