### PR TITLE
[SHOT-4192] Add the possibility to specify a thumbnail when publishing using the API

### DIFF
--- a/python/tk_multi_publish2/api/item.py
+++ b/python/tk_multi_publish2/api/item.py
@@ -399,11 +399,11 @@ class PublishItem(object):
         if self._current_temp_file_path:
             return self._current_temp_file_path
 
-        if self.thumbnail is None:
-            return None
-
         # nothing to do if running without a UI
         if not sgtk.platform.current_engine().has_ui:
+            return None
+
+        if self.thumbnail is None:
             return None
 
         temp_path = tempfile.NamedTemporaryFile(

--- a/python/tk_multi_publish2/api/item.py
+++ b/python/tk_multi_publish2/api/item.py
@@ -392,10 +392,6 @@ class PublishItem(object):
         :returns: Path to a file on disk or None if no thumbnail set
         """
 
-        # nothing to do if running without a UI
-        if not sgtk.platform.current_engine().has_ui:
-            return None
-
         # the thumbnail path was explicitly provided
         if self._thumbnail_path:
             return self._thumbnail_path
@@ -404,6 +400,10 @@ class PublishItem(object):
             return self._current_temp_file_path
 
         if self.thumbnail is None:
+            return None
+
+        # nothing to do if running without a UI
+        if not sgtk.platform.current_engine().has_ui:
             return None
 
         temp_path = tempfile.NamedTemporaryFile(


### PR DESCRIPTION
When we're using the Publish API to publish items, and if the item has a thumbnail path specified, it is not taken into account. We should be able to use it even in batch mode because we don't have to deal with QT as it's only a path, not an image