### PR TITLE
Update MutableMapping module depending on the Python version

### DIFF
--- a/python/tk_multi_publish2/api/data.py
+++ b/python/tk_multi_publish2/api/data.py
@@ -8,14 +8,20 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-import collections
+
 import sgtk
 import copy
+# https://stackoverflow.com/questions/70943244/attributeerror-module-collections-has-no-attribute-mutablemapping
+if sys.version_info.major == 3 and sys.version_info.minor >= 10:
+
+    from collections.abc import MutableMapping
+else:
+    from collections import MutableMapping
 
 logger = sgtk.platform.get_logger(__name__)
 
 
-class PublishData(collections.MutableMapping):
+class PublishData(MutableMapping):
     """
     A simple dictionary-like object for storing/serializing arbitrary publish
     data.


### PR DESCRIPTION
The code above checks which version of Python is installed and imports MutableMapping from collections.abc if it is at least 3.10. Otherwise MutableMapping will be imported from the collections library.