### PR TITLE
SG-30404 Handle list and non list publish_data

### DIFF
--- a/hooks/upload_version.py
+++ b/hooks/upload_version.py
@@ -226,7 +226,9 @@ class UploadVersionPlugin(HookBaseClass):
 
         if "sg_publish_data" in item.properties:
             publish_data = item.properties["sg_publish_data"]
-            version_data["published_files"] = [publish_data]
+            if not isinstance(publish_data, list):
+                publish_data = [publish_data]
+            version_data["published_files"] = publish_data
 
         if settings["Link Local File"].value:
             version_data["sg_path_to_movie"] = path


### PR DESCRIPTION
This is very useful if you want to link multiple published files as the field is a multi-entity.

It can happen when you generate extra published files from a main one (like generating fbx files from a maya scene for instance)