### PR TITLE
SG-30075 address python 3 10 deprecation collections

### DIFF
--- a/python/tk_multi_publish2/api/data.py
+++ b/python/tk_multi_publish2/api/data.py
@@ -8,14 +8,20 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-import collections
+
 import sgtk
 import copy
+# https://stackoverflow.com/questions/70943244/attributeerror-module-collections-has-no-attribute-mutablemapping
+if sys.version_info.major == 3 and sys.version_info.minor >= 10:
+
+    from collections.abc import MutableMapping
+else:
+    from collections import MutableMapping
 
 logger = sgtk.platform.get_logger(__name__)
 
 
-class PublishData(collections.MutableMapping):
+class PublishData(MutableMapping):
     """
     A simple dictionary-like object for storing/serializing arbitrary publish
     data.

--- a/python/tk_multi_publish2/api/data.py
+++ b/python/tk_multi_publish2/api/data.py
@@ -13,12 +13,10 @@ import sgtk
 import copy
 import sys
 
-# https://stackoverflow.com/questions/70943244/attributeerror-module-collections-has-no-attribute-mutablemapping
-if sys.version_info.major == 3 and sys.version_info.minor >= 10:
-
-    from collections.abc import MutableMapping
-else:
+if sys.version_info.major < 3 or (sys.version_info.major == 3 and sys.version_info.minor < 3):
     from collections import MutableMapping
+else:
+    from collections.abc import MutableMapping
 
 logger = sgtk.platform.get_logger(__name__)
 

--- a/python/tk_multi_publish2/api/data.py
+++ b/python/tk_multi_publish2/api/data.py
@@ -13,7 +13,9 @@ import sgtk
 import copy
 import sys
 
-if sys.version_info.major < 3 or (sys.version_info.major == 3 and sys.version_info.minor < 3):
+if sys.version_info.major < 3 or (
+    sys.version_info.major == 3 and sys.version_info.minor < 3
+):
     from collections import MutableMapping
 else:
     from collections.abc import MutableMapping

--- a/python/tk_multi_publish2/api/data.py
+++ b/python/tk_multi_publish2/api/data.py
@@ -11,6 +11,8 @@
 
 import sgtk
 import copy
+import sys
+
 # https://stackoverflow.com/questions/70943244/attributeerror-module-collections-has-no-attribute-mutablemapping
 if sys.version_info.major == 3 and sys.version_info.minor >= 10:
 


### PR DESCRIPTION
Deprecated since version 3.3, will be removed in version 3.10: Moved [Collections Abstract Base Classes](https://docs.python.org/3.9/library/collections.abc.html#collections-abstract-base-classes) to the [collections.abc](https://docs.python.org/3.9/library/collections.abc.html#module-collections.abc) module. For backward compatibility, they continue to be visible in this module through Python 3.9.

Ref. https://docs.python.org/3.9/library/collections.html


This PR 
Resolves #163 
Resolves #167