### PR TITLE
SG-32840: Fix for publishing PDF files

### DIFF
--- a/hooks/collector.py
+++ b/hooks/collector.py
@@ -138,7 +138,7 @@ class BasicSceneCollector(HookBaseClass):
                 "PDF": {
                     "extensions": ["pdf"],
                     "icon": self._get_icon_path("file.png"),
-                    "item_type": "file.image",
+                    "item_type": "file.pdf",
                 },
             }
 

--- a/hooks/upload_version.py
+++ b/hooks/upload_version.py
@@ -114,7 +114,7 @@ class UploadVersionPlugin(HookBaseClass):
         """
 
         # we use "video" since that's the mimetype category.
-        return ["file.image", "file.video"]
+        return ["file.image", "file.pdf", "file.video"]
 
     def accept(self, settings, item):
         """


### PR DESCRIPTION
* When PDF files are categorized as 'file.image', the pdf file path is used as the thumbnail; however the ShotGrid REST API request upload/api_link_file cannot handle a PDF file (must be an image), thus causing an API error
* Fix publishing PDF files by categorizing them as their own file type 'file.pdf'.
* Thumbnail for Published File is only uploaded if user uses the screen grab (not auto generated as it tried before). The Version will get a thumbnail auto generated (via uploading to the sg_uploaded_movie field)