### PR TITLE
SG-33587 QT6 Maya Beta: The Checkboxes in the Publish Window Do Not Work

### DIFF
--- a/python/tk_multi_publish2/publish_tree_widget/custom_widget_item.py
+++ b/python/tk_multi_publish2/publish_tree_widget/custom_widget_item.py
@@ -74,6 +74,9 @@ class CustomTreeWidgetItem(CustomTreeWidgetBase):
         """
         Callback that fires when the user clicks the checkbox
         """
+        # Convert integer state to CheckState enum if necessary
+        if isinstance(state, int):
+            state = QtCore.Qt.CheckState(state)
         self._tree_node.set_check_state(state)
 
     def _on_status_click(self):

--- a/python/tk_multi_publish2/publish_tree_widget/custom_widget_item.py
+++ b/python/tk_multi_publish2/publish_tree_widget/custom_widget_item.py
@@ -75,7 +75,7 @@ class CustomTreeWidgetItem(CustomTreeWidgetBase):
         Callback that fires when the user clicks the checkbox
         """
         # Convert integer state to CheckState enum if necessary
-        if isinstance(state, int):
+        if not isinstance(state, QtCore.Qt.CheckState):
             state = QtCore.Qt.CheckState(state)
         self._tree_node.set_check_state(state)
 

--- a/python/tk_multi_publish2/publish_tree_widget/custom_widget_item.py
+++ b/python/tk_multi_publish2/publish_tree_widget/custom_widget_item.py
@@ -74,7 +74,8 @@ class CustomTreeWidgetItem(CustomTreeWidgetBase):
         """
         Callback that fires when the user clicks the checkbox
         """
-        # Convert integer state to CheckState enum if necessary
+        # For PySide6 compatibility, convert state to CheckState enum if not already
+        # an instance. Issue described at: https://forum.qt.io/post/743017
         if not isinstance(state, QtCore.Qt.CheckState):
             state = QtCore.Qt.CheckState(state)
         self._tree_node.set_check_state(state)

--- a/python/tk_multi_publish2/publish_tree_widget/custom_widget_task.py
+++ b/python/tk_multi_publish2/publish_tree_widget/custom_widget_task.py
@@ -55,7 +55,7 @@ class CustomTreeWidgetTask(CustomTreeWidgetBase):
         Callback that fires when the user clicks the checkbox
         """
         # Convert integer state to CheckState enum if necessary
-        if isinstance(state, int):
+        if not isinstance(state, QtCore.Qt.CheckState):
             state = QtCore.Qt.CheckState(state)
         if QtGui.QApplication.keyboardModifiers() == QtCore.Qt.ShiftModifier:
             logger.debug("shift held. propagating check to all plugins.")

--- a/python/tk_multi_publish2/publish_tree_widget/custom_widget_task.py
+++ b/python/tk_multi_publish2/publish_tree_widget/custom_widget_task.py
@@ -54,6 +54,9 @@ class CustomTreeWidgetTask(CustomTreeWidgetBase):
         """
         Callback that fires when the user clicks the checkbox
         """
+        # Convert integer state to CheckState enum if necessary
+        if isinstance(state, int):
+            state = QtCore.Qt.CheckState(state)
         if QtGui.QApplication.keyboardModifiers() == QtCore.Qt.ShiftModifier:
             logger.debug("shift held. propagating check to all plugins.")
             self._tree_node.set_check_state(state, apply_to_all_plugins=True)

--- a/python/tk_multi_publish2/publish_tree_widget/custom_widget_task.py
+++ b/python/tk_multi_publish2/publish_tree_widget/custom_widget_task.py
@@ -54,7 +54,9 @@ class CustomTreeWidgetTask(CustomTreeWidgetBase):
         """
         Callback that fires when the user clicks the checkbox
         """
-        # Convert integer state to CheckState enum if necessary
+        # For PySide6 compatibility, convert state to CheckState enum if not already
+        # an instance. Issue described at: https://forum.qt.io/post/743017
+
         if not isinstance(state, QtCore.Qt.CheckState):
             state = QtCore.Qt.CheckState(state)
         if QtGui.QApplication.keyboardModifiers() == QtCore.Qt.ShiftModifier:

--- a/python/tk_multi_publish2/publish_tree_widget/custom_widget_task.py
+++ b/python/tk_multi_publish2/publish_tree_widget/custom_widget_task.py
@@ -56,7 +56,6 @@ class CustomTreeWidgetTask(CustomTreeWidgetBase):
         """
         # For PySide6 compatibility, convert state to CheckState enum if not already
         # an instance. Issue described at: https://forum.qt.io/post/743017
-
         if not isinstance(state, QtCore.Qt.CheckState):
             state = QtCore.Qt.CheckState(state)
         if QtGui.QApplication.keyboardModifiers() == QtCore.Qt.ShiftModifier:


### PR DESCRIPTION
This PR addresses an issue where the `stateChanged` signal from `QCheckBox` was emitting an integer type instead of a `Qt.CheckState` enum. This anomaly was leading to unexpected behavior where the Publish App UI checkboxes could not be checked properly. To ensure compatibility and maintain the expected behavior across PySide2 and PySide6, this explicitly convert the emitted integer to a `Qt.CheckState` enum within the slot that handles checkbox state changes.

### Changes

- Updated the `_on_checkbox_click` slot method to check if the `state` argument is an instance of `int`.
- If an integer value  is received as status, it is converted to the corresponding `Qt.CheckState` enum using `Qt.CheckState(state)`.

Closes #180 
Closes #184 