### PR TITLE
SHOT-4365: Update upload version plugin to include .avi files

### DIFF
--- a/hooks/upload_version.py
+++ b/hooks/upload_version.py
@@ -89,7 +89,7 @@ class UploadVersionPlugin(HookBaseClass):
         return {
             "File Extensions": {
                 "type": "str",
-                "default": "jpeg, jpg, png, mov, mp4, pdf",
+                "default": "jpeg, jpg, png, mov, mp4, pdf, avi",
                 "description": "File Extensions of files to include",
             },
             "Upload": {


### PR DESCRIPTION
* This will show the Upload Version plugin for .avi files