### PR TITLE
SHOT-4411: Add UI settings option for Background Publishing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
     - id: trailing-whitespace
   # Leave black at the bottom so all touchups are done before it is run.
   - repo: https://github.com/ambv/black
-    rev: 22.3.0
+    rev: 25.1.0
     hooks:
     - id: black
       language_version: python3

--- a/hooks/collector.py
+++ b/hooks/collector.py
@@ -315,7 +315,7 @@ class BasicSceneCollector(HookBaseClass):
 
         file_items = []
 
-        for (image_seq_path, img_seq_files) in img_sequences:
+        for image_seq_path, img_seq_files in img_sequences:
 
             # get info for the extension
             item_info = self._get_item_info(image_seq_path)
@@ -503,7 +503,7 @@ class BasicSceneCollector(HookBaseClass):
             # get all the image mime type image extensions as well
             mimetypes.init()
             types_map = mimetypes.types_map
-            for (ext, mimetype) in types_map.items():
+            for ext, mimetype in types_map.items():
                 if mimetype.startswith("image/"):
                     image_extensions.add(ext.lstrip("."))
 

--- a/python/tk_multi_publish2/api/item.py
+++ b/python/tk_multi_publish2/api/item.py
@@ -146,7 +146,7 @@ class PublishItem(object):
         )
 
         # local
-        for (k, prop_dict) in item_dict["local_properties"].items():
+        for k, prop_dict in item_dict["local_properties"].items():
             new_item._local_properties[k] = PublishData.from_dict(prop_dict)
 
         new_item._parent = parent
@@ -230,7 +230,7 @@ class PublishItem(object):
         """
 
         converted_local_properties = {}
-        for (k, prop) in self._local_properties.items():
+        for k, prop in self._local_properties.items():
             converted_local_properties[k] = prop.to_dict()
 
         context_value = None

--- a/python/tk_multi_publish2/api/task.py
+++ b/python/tk_multi_publish2/api/task.py
@@ -65,7 +65,7 @@ class PublishTask(object):
         new_task._enabled = task_dict["enabled"]
 
         # create all the setting instances from the data
-        for (k, setting) in task_dict["settings"].items():
+        for k, setting in task_dict["settings"].items():
             new_setting = PluginSetting(
                 setting["name"],
                 setting["type"],
@@ -89,7 +89,7 @@ class PublishTask(object):
 
         # need to make a deep copy of the settings as they may be modified
         self._settings = {}
-        for (setting_name, setting) in plugin.settings.items():
+        for setting_name, setting in plugin.settings.items():
             self._settings[setting_name] = copy.deepcopy(setting)
 
         self._active = checked
@@ -106,7 +106,7 @@ class PublishTask(object):
 
         # Convert each of the settings to a dictionary.
         converted_settings = {}
-        for (k, setting) in self._settings.items():
+        for k, setting in self._settings.items():
             converted_settings[k] = setting.to_dict()
 
         # build the full dictionary representation of this task

--- a/python/tk_multi_publish2/dialog.py
+++ b/python/tk_multi_publish2/dialog.py
@@ -252,10 +252,19 @@ class AppDialog(QtGui.QWidget):
         bg_publish_app = self._bundle.engine.apps.get("tk-multi-bg-publish", None)
         if bg_publish_app:
             # Create the checkbox for enabling background processing
-            self.bg_publish_checkbox = QtGui.QCheckBox("Perform publish in a background process")
-            default_bg_process = self._bundle.get_setting("collector_settings", {}).get("Background Processing", False)
+            self.bg_publish_checkbox = QtGui.QCheckBox(
+                "Perform publish in the background"
+            )
+            self.bg_publish_checkbox.setToolTip(
+                "When checked, you may continue working in the DCC while the publish is performed in a background process. Open the Background Publish Monitor to see your publish progress."
+            )
+            default_bg_process = self._bundle.get_setting("collector_settings", {}).get(
+                "Background Processing", False
+            )
             self.bg_publish_checkbox.setChecked(default_bg_process)
-            self.bg_publish_checkbox.stateChanged.connect(lambda state=None: self._set_bg_processing())
+            self.bg_publish_checkbox.stateChanged.connect(
+                lambda state=None: self._set_bg_processing()
+            )
             # Add the checkbox to the settings widget layout
             settings_layout = self.ui.item_settings.layout()
             settings_layout.addWidget(self.bg_publish_checkbox)

--- a/python/tk_multi_publish2/dialog.py
+++ b/python/tk_multi_publish2/dialog.py
@@ -1223,6 +1223,7 @@ class AppDialog(QtGui.QWidget):
 
         # hide the action buttons during publish
         self.ui.button_container.hide()
+        self.ui.item_settings.setEnabled(False)
 
         # Make sure that settings from the current selection are retrieved from the UI and applied
         # back on the tasks.
@@ -1241,6 +1242,7 @@ class AppDialog(QtGui.QWidget):
                         "Validation errors detected. " "Not proceeding with publish."
                     )
                     self.ui.button_container.show()
+                    self.ui.item_settings.setEnabled(True)
                     return
 
             # validation not required on publish, it has already run though
@@ -1263,6 +1265,7 @@ class AppDialog(QtGui.QWidget):
                 if button_clicked == QtGui.QMessageBox.Cancel:
                     # user does not want ot continue.
                     self.ui.button_container.show()
+                    self.ui.item_settings.setEnabled(True)
                     return
 
                 self._progress_handler.logger.info("User skipped validation step.")
@@ -1270,6 +1273,7 @@ class AppDialog(QtGui.QWidget):
             if self._stop_processing_flagged:
                 # stop processing
                 self.ui.button_container.show()
+                self.ui.item_settings.setEnabled(True)
                 return
 
             # inform the progress system of the current mode
@@ -1321,6 +1325,7 @@ class AppDialog(QtGui.QWidget):
             if self._stop_processing_flagged:
                 self._progress_handler.logger.info("Processing aborted by user.")
                 self.ui.button_container.show()
+                self.ui.item_settings.setEnabled(True)
                 return
 
         finally:
@@ -1374,6 +1379,7 @@ class AppDialog(QtGui.QWidget):
         self.ui.close.hide()
 
         self.ui.button_container.show()
+        self.ui.item_settings.setEnabled(True)
 
         # hide summary overlay
         self._overlay.hide()

--- a/python/tk_multi_publish2/progress/progress_handler.py
+++ b/python/tk_multi_publish2/progress/progress_handler.py
@@ -115,6 +115,7 @@ class ProgressHandler(object):
         """
         reveals the last log entry associated with the given publish instance.
         """
+
         # find the last message matching the task or item
         def _check_r(parent):
             for child_index in range(parent.childCount())[::-1]:

--- a/python/tk_multi_publish2/settings_widget.py
+++ b/python/tk_multi_publish2/settings_widget.py
@@ -67,7 +67,7 @@ class SettingsWidget(QtGui.QWidget):
         self.ui.setupUi(self)
 
         # Set spacing between widgets within the settings widget
-        self.layout().setSpacing(10)
+        self.layout().setSpacing(15)
 
         # Hide the settings scroll area until widgets are added
         self.ui.settings_scroll_area.hide()

--- a/python/tk_multi_publish2/settings_widget.py
+++ b/python/tk_multi_publish2/settings_widget.py
@@ -66,6 +66,11 @@ class SettingsWidget(QtGui.QWidget):
         self.ui = Ui_SettingsWidget()
         self.ui.setupUi(self)
 
+        # Set spacing between widgets within the settings widget
+        self.layout().setSpacing(10)
+
+        # Hide the settings scroll area until widgets are added
+        self.ui.settings_scroll_area.hide()
         self._widgets = []
 
     def clear(self):
@@ -90,6 +95,7 @@ class SettingsWidget(QtGui.QWidget):
 
         finally:
             # make the window visible again and trigger a redraw
+            self.ui.settings_scroll_area.hide()
             self.setVisible(True)
 
     def set_data(self, settings):
@@ -139,6 +145,7 @@ class SettingsWidget(QtGui.QWidget):
             self.ui.settings_layout.setRowStretch(curr_row, 1)
         finally:
             # make the window visible again and trigger a redraw
+            self.ui.settings_scroll_area.show()
             self.setVisible(True)
 
     def set_static_data(self, settings):
@@ -185,4 +192,5 @@ class SettingsWidget(QtGui.QWidget):
             self.ui.settings_layout.setRowStretch(curr_row, 1)
         finally:
             # make the window visible again and trigger a redraw
+            self.ui.settings_scroll_area.show()
             self.setVisible(True)

--- a/python/tk_multi_publish2/settings_widget.py
+++ b/python/tk_multi_publish2/settings_widget.py
@@ -167,7 +167,7 @@ class SettingsWidget(QtGui.QWidget):
             # now create new items - order alphabetically
             curr_row = 0
 
-            for (name, value) in settings:
+            for name, value in settings:
                 field_label = FieldNameLabel(self)
                 field_label.setText(name)
                 field_label.setWordWrap(True)

--- a/tests/fixtures/configInheritance/hooks/collector.py
+++ b/tests/fixtures/configInheritance/hooks/collector.py
@@ -285,7 +285,7 @@ class BasicSceneCollector(HookBaseClass):
 
         file_items = []
 
-        for (image_seq_path, img_seq_files) in img_sequences:
+        for image_seq_path, img_seq_files in img_sequences:
 
             # get info for the extension
             item_info = self._get_item_info(image_seq_path)
@@ -473,7 +473,7 @@ class BasicSceneCollector(HookBaseClass):
             # get all the image mime type image extensions as well
             mimetypes.init()
             types_map = mimetypes.types_map
-            for (ext, mimetype) in types_map.items():
+            for ext, mimetype in types_map.items():
                 if mimetype.startswith("image/"):
                     image_extensions.add(ext.lstrip("."))
 


### PR DESCRIPTION
* Currently the Background Publishing option can only be turned on/off by the config settings
* Add checkbox to publish app UI to make it more convenient for users to turn background publishing on/off
* Use the existing Settings widget in the publish app (currently just hidden) to show the new background publish option
* The background publish option will only show up when the current running engine supports background publishing (e.g. has tk-multi-bg-publish app configured)