### PR TITLE
Fixed logging checkstate error

### DIFF
--- a/python/tk_multi_publish2/publish_tree_widget/publish_tree_widget.py
+++ b/python/tk_multi_publish2/publish_tree_widget/publish_tree_widget.py
@@ -472,7 +472,7 @@ class PublishTreeWidget(QtGui.QTreeWidget):
         :param plugin: Plugin for which tasks should be manipulated
         :param state: checkstate to set.
         """
-        logger.debug("Setting state %d for all plugin %s" % (state, plugin))
+        logger.debug("Setting state %s for all plugin %s" % (state, plugin))
 
         def _check_r(parent):
             for child_index in range(parent.childCount()):

--- a/tests/test_tree_widget.py
+++ b/tests/test_tree_widget.py
@@ -42,17 +42,11 @@ class TestPublishTreeWidget(PublishApiTestBase):
         from sgtk.platform.qt import QtCore, QtGui
 
         def iter_check_states(plugin):
-            yield from (
-                tree_item.check_state
-                for it in QtGui.QTreeWidgetItemIterator(tree_widget)
-                if (
-                    (tree_item := it.value())
-                    and isinstance(
-                        task := tree_item.get_publish_instance(), self.api.PublishTask
-                    )
-                    and task.plugin == plugin
-                )
-            )
+            for it in QtGui.QTreeWidgetItemIterator(tree_widget):
+                tree_item = it.value()
+                task = tree_item.get_publish_instance()
+                if isinstance(task, self.api.PublishTask) and task.plugin == plugin:
+                    yield tree_item.check_state
 
         tree_widget.set_check_state_for_all_plugins(local_plugin, QtCore.Qt.Checked)
         for check_state in iter_check_states(local_plugin):


### PR DESCRIPTION
Super simple fix for broken `Shift-Click` on checkboxes to toggle all tasks from that plugin


<img width="1075" height="735" alt="image" src="https://github.com/user-attachments/assets/aaff60d7-cf96-497b-92d7-77cc3d04a798" />


i.e. as recently as `v2.10.7`, doing the above would have no effect and instead throw the error:

```python
Traceback (most recent call last):
  File "/path/to/cloned/tk-multi-publish2/python/tk_multi_publish2/publish_tree_widget/custom_widget_task.py", line 63, in _on_checkbox_click
    self._tree_node.set_check_state(state, apply_to_all_plugins=True)
  File "/path/to/cloned/tk-multi-publish2/python/tk_multi_publish2/publish_tree_widget/tree_node_task.py", line 72, in set_check_state
    self.treeWidget().set_check_state_for_all_plugins(self._task.plugin, state)
  File "/path/to/cloned/tk-multi-publish2/python/tk_multi_publish2/publish_tree_widget/publish_tree_widget.py", line 475, in set_check_state_for_all_plugins
    logger.debug("Setting state %d for all plugin %s" % (state, plugin))
                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
TypeError: %d format: a real number is required, not CheckState
```