### PR TITLE
SG-42049: Update README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![Reference Documentation](http://img.shields.io/badge/doc-reference-blue.svg)](http://developer.shotgridsoftware.com/tk-multi-publish2)
 [![Build Status](https://dev.azure.com/shotgun-ecosystem/Toolkit/_apis/build/status/shotgunsoftware.tk-multi-publish2?branchName=master)](https://dev.azure.com/shotgun-ecosystem/Toolkit/_build/latest?definitionId=41&branchName=master)
 [![codecov](https://codecov.io/gh/shotgunsoftware/tk-multi-publish2/branch/master/graph/badge.svg)](https://codecov.io/gh/shotgunsoftware/tk-multi-publish2)
-[![Linting](https://img.shields.io/badge/PEP8%20by-Hound%20CI-a873d1.svg)](https://houndci.com)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
 


### PR DESCRIPTION
Removes deprecated HoundCI badge from README.

Related SG-42049 PRs:
- shotgunsoftware/tk-aftereffects#63
- shotgunsoftware/tk-core#1084
- shotgunsoftware/tk-framework-desktopclient#36
- shotgunsoftware/tk-framework-qtwidgets#181
- shotgunsoftware/tk-framework-shotgunutils#177
- shotgunsoftware/tk-framework-widget#31
- shotgunsoftware/tk-multi-about#36
- shotgunsoftware/tk-multi-breakdown#45
- shotgunsoftware/tk-multi-demo#48
- shotgunsoftware/tk-multi-launchapp#111
- shotgunsoftware/tk-multi-loader2#135
- shotgunsoftware/tk-multi-publish2#211
- shotgunsoftware/tk-multi-pythonconsole#44
- shotgunsoftware/tk-multi-reviewsubmission#51
- shotgunsoftware/tk-multi-screeningroom#26
- shotgunsoftware/tk-multi-snapshot#50
- shotgunsoftware/tk-multi-workfiles2#170
- shotgunsoftware/tk-shell#38