### PR TITLE
Extensible display_hook

### DIFF
--- a/docs/hooks.rst
+++ b/docs/hooks.rst
@@ -80,8 +80,9 @@ it.
 
     display:
         type: dict
-        description: Hook and settings that defines how the command/action to
-                     show the publish dialog is displayed
+        description: Hook and settings that implements the values of various GUI
+                     elements of the publish dialog such as window title, menu name
+                     that launches the dialog, button label, etc.
         items:
             hook: {type: hook}
             settings: {type: dict, allows_empty: True}

--- a/docs/hooks.rst
+++ b/docs/hooks.rst
@@ -1,0 +1,157 @@
+Hooks
+=====
+
+Apart from the core collector and publish plugin hooks and settings, many other
+parts of the publishing process and GUI can be customized by defining and extending
+various hook configurations. The specifications are defined in the ``info.yml``
+file at the root of the code repository.
+
+
+Publishing
+----------
+
+.. code-block:: yaml
+    :caption: info.yml
+
+    post_phase:
+        type: hook
+        description:
+          "A hook that defines logic to be executed after each phase of publish
+          execution including validation, publish, and finalization. This allows
+          for very specific curation and customization of the publish tree
+          during a publish session. Serializing the publish tree to disk after
+          validation, for example is possible via this hook."
+        default_value: "{self}/post_phase.py"
+
+    pre_publish:
+        type: hook
+        description:
+          "This hook defines logic to be executed before showing the publish
+          dialog. There may be conditions that need to be checked before allowing
+          the user to proceed to publishing."
+        default_value: "{self}/pre_publish.py"
+
+    path_info:
+        type: hook
+        description:
+          "This hook contains methods that are used during publishing to infer
+           information from file paths. This includes version and frame number
+           identification, publish display name, image sequence paths, etc."
+        default_value: "{self}/path_info.py"
+
+    thumbnail_generator:
+        type: hook
+        description:
+          "This hook contains methods that are used during publishing to auto
+          generate a thumbnail from the file being published."
+        default_value: "{self}/thumbnail_generator.py"
+
+GUI
+---
+
+For basic GUI customizations, these configurations can be used/modified:
+
+.. code-block:: yaml
+    :caption: info.yml
+
+    display_name:
+        type: str
+        default_value: Publish
+        description: Specify the name that should be used in menus and the main
+                     publish dialog
+
+    display_action_name:
+        type: str
+        default_value: Publish
+        description: "Shorter version of display_name setting, used as button name."
+
+
+Display Hook and Settings
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. versionadded:: v2.x.x
+
+When more advanced GUI customizations are needed, the ``display`` configuration
+can be used to extend and customize the display hook and any settings to feed into
+it.
+
+.. code-block:: yaml
+    :caption: info.yml
+
+    display:
+        type: dict
+        description: Hook and settings that defines how the command/action to
+                     show the publish dialog is displayed
+        items:
+            hook: {type: hook}
+            settings: {type: dict, allows_empty: True}
+        default_value:
+            hook: "{self}/display_hook.py"
+            settings: {}
+
+By default, it uses the values from ``display_name`` and ``display_action_name``
+configurations across various menu text, window title, button label, etc.
+
+These can all be overridden as much as needed. The ``display:settings`` values
+are free for developers to define and use as they see fit for their custom
+``display:hook`` implementations.
+
+Here is an exaggerated simple example where each part are defined via custom
+``display:settings``, except ``menu_properties()`` which remains inherited from the
+default ``{self}/display_hook.py``.
+
+.. code-block:: yaml
+    :caption: Example tk-config-default2/env/includes/settings/tk-multi-publish2.yml
+    :emphasize-lines: 11-19
+
+    settings.tk-multi-publish2.standalone:
+      collector: "{self}/collector.py"
+      publish_plugins:
+      - name: Publish to Flow Production Tracking
+        hook: "{self}/publish_file.py"
+        settings: {}
+      - name: Upload for review
+        hook: "{self}/upload_version.py"
+        settings: {}
+      help_url: *help_url
+      display:
+        hook:
+          "{self}/display_hook.py\
+          :{config}/hooks/tk-multi-publish2/display_hook.py"
+        settings:
+          action_name: Verb
+          button_name: Click Me
+          window_title: I'm Here
+          menu_name: Publish Stuff
+      location: "@apps.tk-multi-publish2.location"
+
+.. code-block:: python
+    :caption: Example tk-config-default2/hooks/tk-multi-publish2/display_hook.py
+
+    import sgtk
+
+    HookBaseClass = sgtk.get_hook_baseclass()
+
+
+    class SettingsBasedDisplayHook(HookBaseClass):
+        """Hook that defines how the action to show the publish dialog is displayed."""
+
+        @property
+        def action_name(self) -> str:
+            """Text (verb) used when referring to the _Publish_ action in the GUI."""
+            return self.settings["action_name"]
+
+        @property
+        def button_name(self) -> str:
+            """Label text used for the _Publish_ button."""
+            return self.settings["button_name"]
+
+        @property
+        def window_title(self) -> str:
+            """Window title used for `.Engine.show_modal`/`.Engine.show_dialog`."""
+            return self.settings["window_title"]
+
+        @property
+        def menu_name(self) -> str:
+            """Command name used when registering the show dialog command to menus."""
+            return self.settings["menu_name"]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -106,3 +106,4 @@ for publish workflow building and customization.
     logging
     utility
     application
+    hooks

--- a/hooks/display_hook.py
+++ b/hooks/display_hook.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2026 Autodesk.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the ShotGrid Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the ShotGrid Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Autodesk.
+"""Hook that defines how the command/action to show the publish dialog is displayed.
+
+The output of methods in this hook are used as follows when calling
+`.sgtk.platform.Application.register_command`::
+
+    app.register_command(
+        app.execute_hook_method("display_hook", "menu_name"),
+        ...,
+        properties=app.execute_hook_method("display_hook", "menu_properties"),
+    )
+"""
+
+import os
+import re
+from typing import Any
+
+import sgtk
+
+HookBaseClass = sgtk.get_hook_baseclass()
+
+
+class DisplayHook(HookBaseClass):
+    """Hook that defines how the action to show the publish dialog is displayed."""
+
+    @property
+    def settings(self) -> dict[str, Any]:
+        """Return the settings that are available for this hook."""
+        return self.parent.get_setting("display").get("settings") or {}
+
+    @property
+    def action_name(self) -> str:
+        """Create text used when inferring to the "Publish" action in the GUI."""
+        return self.parent.get_setting("display_action_name")
+
+    @property
+    def button_name(self) -> str:
+        """Create the label text used when for "Publish" button."""
+        return self.action_name
+
+    @property
+    def menu_name(self) -> str:
+        """Create the command name used when registering the show dialog command."""
+        return f"{self.parent.get_setting('display_name')}..."
+
+    @property
+    def menu_properties(self) -> dict[str, Any]:
+        """Create the properties used when registering the show dialog command.
+
+        See expected property details at `.sgtk.platform.Application.register_command`.
+        """
+        display_name = self.parent.get_setting("display_name")
+        command_name = re.sub(r"[^0-9a-zA-Z]+", "_", display_name.lower())
+
+        return {
+            "short_name": command_name,
+            "description": "Publishing of data to Flow Production Tracking",
+            "icons": {
+                "dark": {
+                    "png": os.path.join(self.parent.disk_location, "icon_256_dark.png")
+                }
+            },
+        }

--- a/hooks/display_hook.py
+++ b/hooks/display_hook.py
@@ -38,22 +38,27 @@ class DisplayHook(HookBaseClass):
 
     @property
     def action_name(self) -> str:
-        """Create text used when inferring to the "Publish" action in the GUI."""
+        """Text (verb) used when referring to the _Publish_ action in the GUI."""
         return self.parent.get_setting("display_action_name")
 
     @property
     def button_name(self) -> str:
-        """Create the label text used when for "Publish" button."""
+        """Label text used for the _Publish_ button."""
         return self.action_name
 
     @property
+    def window_title(self) -> str:
+        """Window title used for `.Engine.show_modal`/`.Engine.show_dialog`."""
+        return self.parent.get_setting("display_name")
+
+    @property
     def menu_name(self) -> str:
-        """Create the command name used when registering the show dialog command."""
+        """Command name used when registering the show dialog command to menus."""
         return f"{self.parent.get_setting('display_name')}..."
 
     @property
     def menu_properties(self) -> dict[str, Any]:
-        """Create the properties used when registering the show dialog command.
+        """Properties used when registering the show dialog command.
 
         See expected property details at `.sgtk.platform.Application.register_command`.
         """

--- a/info.yml
+++ b/info.yml
@@ -15,6 +15,17 @@ configuration:
         description: Specify the name that should be used in menus and the main
                      publish dialog
 
+    display:
+        type: dict
+        description: Hook and settings that defines how the command/action to
+                     show the publish dialog is displayed
+        items:
+            hook: {type: hook}
+            settings: {type: dict, allows_empty: True}
+        default_value:
+            hook: "{self}/display_hook.py"
+            settings: {}
+
     display_action_name:
         type: str
         default_value: Publish

--- a/info.yml
+++ b/info.yml
@@ -17,8 +17,9 @@ configuration:
 
     display:
         type: dict
-        description: Hook and settings that defines how the command/action to
-                     show the publish dialog is displayed
+        description: Hook and settings that implements the values of various GUI
+                     elements of the publish dialog such as window title, menu name
+                     that launches the dialog, button label, etc.
         items:
             hook: {type: hook}
             settings: {type: dict, allows_empty: True}

--- a/python/tk_multi_publish2/__init__.py
+++ b/python/tk_multi_publish2/__init__.py
@@ -25,7 +25,7 @@ def show_dialog(app):
     # defer imports so that the app works gracefully in batch modes
     from .dialog import AppDialog
 
-    display_name = sgtk.platform.current_bundle().get_setting("display_name")
+    display_name = sgtk.platform.current_bundle().display_hook.window_title
 
     if app.pre_publish_hook.validate():
         # start ui

--- a/python/tk_multi_publish2/dialog.py
+++ b/python/tk_multi_publish2/dialog.py
@@ -281,8 +281,8 @@ class AppDialog(QtGui.QWidget):
         self._summary_thumbnail = None
 
         # set publish button text
-        self._display_action_name = self._bundle.get_setting("display_action_name")
-        self.ui.publish.setText(self._display_action_name)
+        self._display_action_name = self._bundle.display_hook.action_name
+        self.ui.publish.setText(self._bundle.display_hook.button_name)
 
         # Special UI tweaks based on the 'manual_load_enabled' property
         #

--- a/tests/test_display_hook.py
+++ b/tests/test_display_hook.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2026 Autodesk.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the ShotGrid Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the ShotGrid Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Autodesk.
+import os
+
+from publish_api_test_base import PublishApiTestBase
+from tank_test.tank_test_base import setUpModule  # noqa
+
+
+class TestDisplayHook(PublishApiTestBase):
+    def test_attributes_exist(self):
+        from sgtk import Hook
+
+        assert hasattr(self.app, "display_hook")
+        assert isinstance(self.app.display_hook, Hook)
+        for prop in ("action_name", "button_name", "menu_name", "menu_properties"):
+            assert hasattr(self.app.display_hook, prop)
+
+    def test_matches_v2_10_7(self):
+        """Test new display hook properties match same values from on v2.10.7 tag.
+
+        This ensures drop-in compatibility with existing code and configurations.
+        """
+        app = self.app
+
+        # tk-multi-publish2/app.py:MultiPublish2.init_app()
+        from tank.util import sgre as re
+
+        display_name = app.get_setting("display_name")
+        command_name = display_name.lower()
+        command_name = re.sub(r"[^0-9a-zA-Z]+", "_", command_name)
+        menu_caption = "%s..." % display_name
+        menu_options = {
+            "short_name": command_name,
+            "description": "Publishing of data to Flow Production Tracking",
+            "icons": {
+                "dark": {"png": os.path.join(app.disk_location, "icon_256_dark.png")}
+            },
+        }
+        # self.engine.register_command(menu_caption, cb, menu_options)
+        assert app.display_hook.menu_name == menu_caption
+        assert app.display_hook.menu_properties == menu_options
+
+        # tk-multi-publish2/python/tk_multi_publish2/dialog.py:AppDialog.__init__()
+        display_action_name = app.get_setting("display_action_name")
+        # self._display_action_name = self._bundle.get_setting("display_action_name")
+        # self.ui.publish.setText(self._display_action_name)
+        assert app.display_hook.action_name == display_action_name
+        assert app.display_hook.button_name == display_action_name


### PR DESCRIPTION
Add ability to customise the button text, menu and action names/properties using a hook instead.

Current implementation imitates existing behaviour without changes to any currently authored configs or settings


### Added

- `display` config dict with `hook` and optional `settings`
-  `MultiPublish2.display_hook` get-only property to expose `display:hook` instance

### Changed

- Migrated menu name and properties setup in `MultiPublish2` (app.py)  into `display:hook.menu_name` and  `display:hook.menu_properties` and switched to call them
- Migrated `AppDialog._display_action_name`  logic into `display:hook.action_name` and switched to call it
- Switched text used for `AppDialog.ui.publish`  to use `display:hook.button_name`
  - which continues to use `display:hook.action_name`