### PR TITLE
Resize to fit item/task text

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -132,6 +132,19 @@ configuration:
           "If true the app dialog will be opened in modal window mode, else if
            false (default) the dialog will be opened in non-modal window mode."
 
+    fit_width_to_items:
+        type: str
+        default_value: "always"
+        description: |
+            Determines when the publish dialog should automatically resize its width
+            to fit the contents of the items tree. Valid values are:
+
+            - 'never'   the dialog will never auto resize its width
+            - 'initial' (default) the dialog will auto resize its width once,
+                        when the items tree is first populated
+            - 'always'  the dialog will auto resize its width every time the items
+                        tree is modified (items added/removed)
+
 
 # the Shotgun fields that this app needs in order to operate correctly
 requires_shotgun_fields:

--- a/info.yml
+++ b/info.yml
@@ -134,15 +134,15 @@ configuration:
 
     fit_width_to_items:
         type: str
-        default_value: "always"
+        default_value: "never"
         description: |
             Determines when the publish dialog should automatically resize its width
             to fit the contents of the items tree. Valid values are:
 
-            - 'never'   the dialog will never auto resize its width
-            - 'initial' (default) the dialog will auto resize its width once,
+            - 'never'   (default) The dialog will never auto resize its width
+            - 'initial' The dialog will auto resize its width once,
                         when the items tree is first populated
-            - 'always'  the dialog will auto resize its width every time the items
+            - 'always'  The dialog will auto resize its width every time the items
                         tree is modified (items added/removed)
 
 

--- a/python/tk_multi_publish2/dialog.py
+++ b/python/tk_multi_publish2/dialog.py
@@ -996,7 +996,7 @@ class AppDialog(QtGui.QWidget):
     def _fit_width_to_items(self):  # type: () -> Literal["never", "initial", "always"]
         """Calculate appropriate ``fit_width_to_items`` mode from app settings."""
         known_values = ("never", "initial", "always")
-        default = known_values[1]
+        default = known_values[0]
 
         value = self._bundle.get_setting("fit_width_to_items", default).lower()
         if value not in known_values:

--- a/python/tk_multi_publish2/dialog.py
+++ b/python/tk_multi_publish2/dialog.py
@@ -11,6 +11,7 @@
 import contextlib
 import enum
 import traceback
+from typing import Iterator
 
 import sgtk
 from sgtk.platform.qt import QtCore, QtGui
@@ -1007,7 +1008,7 @@ class AppDialog(QtGui.QWidget):
             return cls.NEVER
 
     @contextlib.contextmanager
-    def _resize_window_for_tree(self):  # type: () -> Iterator[None]
+    def _resize_window_for_tree(self) -> Iterator[None]:
         """Context that resizes the main window to fit the tree items.
 
         Only runs on successful exit of the context. Skips if any of:

--- a/python/tk_multi_publish2/dialog.py
+++ b/python/tk_multi_publish2/dialog.py
@@ -71,7 +71,6 @@ class AppDialog(QtGui.QWidget):
         shotgun_globals.register_bg_task_manager(self._task_manager)
 
         self._bundle = sgtk.platform.current_bundle()
-        sgtk.platform.util.LogManager.global_debug = True
         self._validation_run = False
 
         # set up the UI

--- a/python/tk_multi_publish2/dialog.py
+++ b/python/tk_multi_publish2/dialog.py
@@ -413,6 +413,7 @@ class AppDialog(QtGui.QWidget):
         first_task = items[0].get_publish_instance()
 
         for item in items:
+
             publish_instance = item.get_publish_instance()
             # User has mixed different types of publish instances, it's not just a task list.
             if not isinstance(publish_instance, PublishTask):
@@ -856,7 +857,7 @@ class AppDialog(QtGui.QWidget):
         new_session_items = self._publish_manager.collect_session()
 
         logger.debug(
-            "Refresh: Running collection on all previously collected external files"
+            "Refresh: Running collection on all previously collected external " "files"
         )
         new_file_items = self._publish_manager.collect_files(previously_collected_files)
 
@@ -1302,7 +1303,7 @@ class AppDialog(QtGui.QWidget):
                 # do_validate returns the number of issues encountered
                 if self.do_validate(is_standalone=False) > 0:
                     self._progress_handler.logger.error(
-                        "Validation errors detected. Not proceeding with publish."
+                        "Validation errors detected. " "Not proceeding with publish."
                     )
                     self.ui.button_container.show()
                     self.ui.item_settings.setEnabled(True)
@@ -1411,6 +1412,7 @@ class AppDialog(QtGui.QWidget):
             )
             self._overlay.show_fail()
         else:
+
             # Publish succeeded
             # Log the toolkit "Published" metric
             try:
@@ -1518,6 +1520,7 @@ class AppDialog(QtGui.QWidget):
         list_items = self._get_tree_items()
 
         for ui_item in list_items:
+
             if self._stop_processing_flagged:
                 # jump out of the iteration
                 break


### PR DESCRIPTION
Ability to set new `AppDialog` behaviour on how it would fit PublishItem/PublishTask text upon tree rebuild

- `never`:  the dialog will never auto resize its width (current behaviour)
- `initial`:  the dialog will auto resize its width once,            when the items tree is first populated
- `always`:  the dialog will auto resize its width every time the items            tree is modified (items added/removed)

Tidy up:
- [x] Extra unintended formatting by ruff
- [x] Set defaults to match current behaviour
- [x] Turn off global debug
- [x] Now that we target 3.9+ consider utilising Python `enum`

  
### Added

- `fit_width_to_items` config (str) with options: "never", "initial", "always"
- Internal logic to