### PR TITLE
SG-41994 Using tk-build-qt-resources for #144

### DIFF
--- a/python/tk_multi_publish2/progress/ui/more_info_widget.py
+++ b/python/tk_multi_publish2/progress/ui/more_info_widget.py
@@ -40,6 +40,7 @@ class Ui_MoreInfoWidget(object):
 
         self.message_label = QLabel(MoreInfoWidget)
         self.message_label.setObjectName(u"message_label")
+        self.message_label.setWordWrap(True)
 
         self.horizontalLayout.addWidget(self.message_label)
 

--- a/resources/more_info_widget.ui
+++ b/resources/more_info_widget.ui
@@ -46,6 +46,9 @@
        <property name="text">
         <string>More Info...</string>
        </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
       </widget>
      </item>
     </layout>


### PR DESCRIPTION
Replaces #144 as per https://github.com/shotgunsoftware/tk-multi-publish2/pull/144#issuecomment-3872891113

![really-wide-before-and-after](https://user-images.githubusercontent.com/9294702/122099910-7867de80-ce0a-11eb-8296-22db1e5561c7.png)
### Changed

- Enabled `setWordWrap` so dialog with long error messages, i.e. multi-inheritance publish plugin hook paths, doesn't show as a very very wide window
