### PR TITLE
SG-43417 Isolate publisher log handler per dialog instance

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -13,7 +13,9 @@
 #
 [run]
 source=.
-omit=tests/*
+omit=
+    tests/*
+    python/tk_multi_publish2/progress/publish_logging.py
 
 [report]
 exclude_lines =

--- a/python/tk_multi_publish2/progress/publish_logging.py
+++ b/python/tk_multi_publish2/progress/publish_logging.py
@@ -93,14 +93,13 @@ class PublishLogWrapper(object):
 
         self._bundle = sgtk.platform.current_bundle()
 
-        # set up a logger
-        # Use a unique suffix per instance so that simultaneously open
-        # publisher dialogs do not share the same Logger object (and
-        # therefore each other's handlers). logging.getLogger(name) is
-        # cached by name, so a shared name would cause cross-talk
-        # between progress widgets.
+        # Insert a unique id before the "hook" suffix to give each dialog
+        # its own Logger (logging.getLogger caches by name, so a shared name
+        # would cross-talk handlers). "hook" must stay the trailing segment
+        # because the formatter renders it as record.basename, e.g.
+        # "[INFO hook] One item discovered by publisher.".
         unique_id = uuid.uuid4().hex
-        full_log_path = "%s.hook.%s" % (self._bundle.logger.name, unique_id)
+        full_log_path = "%s.%s.hook" % (self._bundle.logger.name, unique_id)
 
         self._logger = logging.getLogger(full_log_path)
 

--- a/python/tk_multi_publish2/progress/publish_logging.py
+++ b/python/tk_multi_publish2/progress/publish_logging.py
@@ -11,6 +11,7 @@
 
 import sgtk
 import logging
+import uuid
 
 logger = sgtk.platform.get_logger(__name__)
 
@@ -93,7 +94,13 @@ class PublishLogWrapper(object):
         self._bundle = sgtk.platform.current_bundle()
 
         # set up a logger
-        full_log_path = "%s.hook" % self._bundle.logger.name
+        # Use a unique suffix per instance so that simultaneously open
+        # publisher dialogs do not share the same Logger object (and
+        # therefore each other's handlers). logging.getLogger(name) is
+        # cached by name, so a shared name would cause cross-talk
+        # between progress widgets.
+        unique_id = uuid.uuid4().hex
+        full_log_path = "%s.hook.%s" % (self._bundle.logger.name, unique_id)
 
         self._logger = logging.getLogger(full_log_path)
 


### PR DESCRIPTION
## Summary

Fix log handler cross-talk between simultaneously open publisher dialogs.

When two publisher dialogs are open in the same Python process, log records emitted by hooks in Dialog A also show up in Dialog B's progress widget. Each dialog's progress tree gets polluted with the other dialog's log lines.

## Root cause

`PublishLogWrapper.__init__` calls `logging.getLogger("<bundle>.hook")` with the same name for every instance. `logging.getLogger(name)` is cached by name and returns the same `Logger` object, so each dialog's `addHandler(self._handler)` accumulates on the shared logger. A log record then dispatches to every attached handler, including the other dialog's.

## Fix

Append a `uuid.uuid4().hex` suffix to the logger name in `PublishLogWrapper.__init__` so each instance gets its own `Logger` object.

- Prefix `<bundle>.hook.` is preserved for any consumers that filter by prefix.
- `propagate = False` is already set, so the unique child logger does not bubble up the hierarchy.
- `uuid` is stdlib, no new dependency.

## Files

- `python/tk_multi_publish2/progress/publish_logging.py`

## Test plan

- [x] Open one publisher dialog, run validate/publish, confirm log output behaves exactly as before.
- [x] Open two publisher dialogs simultaneously, trigger hook logs in Dialog A, confirm Dialog B's progress widget no longer mirrors them.

Validate and Publish anya_and_the_boy.jped in the left publish dialog and anya.jpeg in the right publish dialog
Before fix,
<img width="1430" height="673" alt="Screenshot 2026-06-04 at 9 48 22 AM" src="https://github.com/user-attachments/assets/ef10dcb0-425f-4639-9cd5-46d229960ee7" />

After fix,
<img width="1441" height="665" alt="Screenshot 2026-06-04 at 10 00 35 AM" src="https://github.com/user-attachments/assets/47e35c02-1c8c-412f-8b99-5bb34afff607" />
