### PR TITLE
SG-43664 Drop Python 3.7 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
     - id: trailing-whitespace
   # Leave black at the bottom so all touchups are done before it is run.
   - repo: https://github.com/ambv/black
-    rev: 26.1.0
+    rev: 26.5.1
     hooks:
     - id: black
       language_version: python3

--- a/info.yml
+++ b/info.yml
@@ -144,6 +144,7 @@ description: "Provides UI and functionality to publish files to Flow Production 
 requires_shotgun_version:
 requires_core_version: "v0.19.4"
 requires_engine_version:
+minimum_python_version: "3.9"
 
 # this app works in all engines - it does not contain
 # any host application specific commands

--- a/python/tk_multi_publish2/api/data.py
+++ b/python/tk_multi_publish2/api/data.py
@@ -11,14 +11,7 @@
 
 import sgtk
 import copy
-import sys
-
-if sys.version_info.major < 3 or (
-    sys.version_info.major == 3 and sys.version_info.minor < 3
-):
-    from collections import MutableMapping
-else:
-    from collections.abc import MutableMapping
+from collections.abc import MutableMapping
 
 logger = sgtk.platform.get_logger(__name__)
 


### PR DESCRIPTION
## Summary
- Set `minimum_python_version: "3.9"` in `info.yml`
- Removed Python 2/early-Python-3 compatibility shim in `api/data.py`: replaced the conditional `collections` / `collections.abc` import with the direct `from collections.abc import MutableMapping` (always available on 3.9+)

## Test plan
- [ ] Pre-commit passes (black, check-ast, check-yaml, whitespace)
- [ ] `PublishData` dict-like API works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)