### PR TITLE
SG-43936 Add int_deps to `create_components_for_publish`

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,4 +46,3 @@ jobs:
     - name: tk-framework-qtwidgets
     - name: tk-framework-shotgunutils
     - name: tk-shell
-    tk_core_ref: ticket/sg-43461/migrate-host-base

--- a/hooks/publish_file.py
+++ b/hooks/publish_file.py
@@ -167,9 +167,7 @@ class BasicFilePublishPlugin(HookBaseClass):
         A file can be published multiple times however only the most recent
         publish will be available to other users. Warnings will be provided
         during validation if there are previous publishes.
-        """ % (
-            loader_url,
-        )
+        """ % (loader_url,)
 
     @property
     def settings(self):
@@ -292,8 +290,7 @@ class BasicFilePublishPlugin(HookBaseClass):
 
         # -- Flow AM: validate project, draft, and asset before stock SG checks
         if self._flow_active():
-            if not self._flow_validate(settings, item):
-                return False
+            return self._flow_validate(settings, item)
 
         # ---- determine the information required to validate
 
@@ -377,6 +374,7 @@ class BasicFilePublishPlugin(HookBaseClass):
         # -- Flow AM: publish to Flow AM, then continue to SG register_publish
         if self._flow_active():
             self._flow_publish(settings, item)
+            return None
 
         # ---- determine the information required to publish
 
@@ -466,6 +464,9 @@ class BasicFilePublishPlugin(HookBaseClass):
         """
 
         publisher = self.parent
+
+        if self._flow_active():
+            return None
 
         # get the data for the publish that was just created in PTR
         publish_data = item.properties.sg_publish_data

--- a/python/tk_multi_publish2/flowam/publish.py
+++ b/python/tk_multi_publish2/flowam/publish.py
@@ -548,7 +548,6 @@ def _save_scene(
         PublishAssetError
     """
     # Retrieve all the dependencies within the scene
-    # NOTE: pretend there are no dep, return empty list
     dep_tree = host.get_dependency_tree()
 
     # Local (external) dependencies aren't supported for now
@@ -592,7 +591,7 @@ def _save_scene(
         msg = f"Could not save current scene to draft path: {draft_path}"
         raise PublishAssetError(data={"draft_path": draft_path}, details=msg) from exc
 
-    return []
+    return int_deps
 
 
 @utils.trace

--- a/python/tk_multi_publish2/flowam/publish.py
+++ b/python/tk_multi_publish2/flowam/publish.py
@@ -132,6 +132,7 @@ def publish_dcc_draft(inputs: PublishInputs) -> PublishInfo | None:
     components = flowam_utils.create_components_for_publish(
         [draft_path],
         thumbnail_path,
+        int_deps,
     )
 
     # Get unique list of versions "used" by current asset - i.e. version ids


### PR DESCRIPTION
Base PR #224

This pull request makes a small update to the `publish_dcc_draft` function in `python/tk_multi_publish2/flowam/publish.py` by passing the `int_deps` variable as an additional argument to the `flowam_utils.create_components_for_publish` function. This ensures that internal dependencies are included when creating publish components.