### PR TITLE
Fix to trigger checkout_revision properly

### DIFF
--- a/python/tk_multi_publish2/flowam/publish.py
+++ b/python/tk_multi_publish2/flowam/publish.py
@@ -662,7 +662,7 @@ def _handle_publish_conflict(host, draft_id: str, exc: PublishConflictError) -> 
             latest_rev = asset.get_latest_revision()
             msg = f"Discarding current draft and checking out revision {latest_rev.revision_number}..."
             logger.info(msg)
-            checkout_revision(latest_rev.id, force=True)
+            open.checkout_revision(latest_rev.id, force=True)
         elif result == 1:
             logger.warning("Publish operation cancelled.")
         else:


### PR DESCRIPTION
This pull request makes a small change to the `publish.py` file, updating how the `checkout_revision` function is called to ensure it's properly referenced.

* Changed the call to `checkout_revision` to use the `open` module or object prefix (`open.checkout_revision`) for improved clarity and correctness in the `_handle_publish_conflict` function.