### PR TITLE
SG-43467 Support background publish in base publish

### DIFF
--- a/hooks/publish_file.py
+++ b/hooks/publish_file.py
@@ -167,7 +167,9 @@ class BasicFilePublishPlugin(HookBaseClass):
         A file can be published multiple times however only the most recent
         publish will be available to other users. Warnings will be provided
         during validation if there are previous publishes.
-        """ % (loader_url,)
+        """ % (
+            loader_url,
+        )
 
     @property
     def settings(self):
@@ -290,6 +292,12 @@ class BasicFilePublishPlugin(HookBaseClass):
 
         # -- Flow AM: validate project, draft, and asset before stock SG checks
         if self._flow_active():
+            # Do not allow background publish to be enabled for Flow publish for now
+            if self._is_deferred_to_bg(item):
+                self.logger.error(
+                    "Background publishing is not currently supported in Flow integration."
+                )
+                return False
             return self._flow_validate(settings, item)
 
         # ---- determine the information required to validate
@@ -373,7 +381,17 @@ class BasicFilePublishPlugin(HookBaseClass):
 
         # -- Flow AM: publish to Flow AM, then continue to SG register_publish
         if self._flow_active():
+            # NOTE: Because we are checking during validation step that bg publish is
+            #       not enabled for flow publishes, we can ignore this case for
+            #       background publishing.
             self._flow_publish(settings, item)
+            return None
+
+        # Exit early if in the live session part of a bg-enabled publish
+        if self._is_deferred_to_bg(item):
+            self.logger.info(
+                "Background publish enabled — deferring publish registration to the background process."
+            )
             return None
 
         # ---- determine the information required to publish
@@ -466,6 +484,13 @@ class BasicFilePublishPlugin(HookBaseClass):
         publisher = self.parent
 
         if self._flow_active():
+            return None
+
+        # Exit early if in the live session part of a bg-enabled publish
+        if self._is_deferred_to_bg(item):
+            self.logger.info(
+                "Background publish enabled — deferring finalize to the background process."
+            )
             return None
 
         # get the data for the publish that was just created in PTR
@@ -1105,6 +1130,17 @@ class BasicFilePublishPlugin(HookBaseClass):
         if "extension" in missing_keys and file_extension:
             fields["extension"] = file_extension
             missing_keys.remove("extension")
+
+    def _is_deferred_to_bg(self, item) -> bool:
+        """Return True if publish item or any ancestor of it has bg publish enabled
+        but we are not currently in a bg process.
+        """
+        root = item
+        while not root.is_root:
+            root = root.parent
+        return bool(root.properties.get("bg_processing")) and not bool(
+            root.properties.get("in_bg_process")
+        )
 
     ############################################################################
     # Flow AM helpers

--- a/hooks/publish_file.py
+++ b/hooks/publish_file.py
@@ -379,7 +379,17 @@ class BasicFilePublishPlugin(HookBaseClass):
 
         # -- Flow AM: publish to Flow AM, then continue to SG register_publish
         if self._flow_active():
+            # NOTE: Because we are checking during validation step that bg publish is
+            #       not enabled for flow publishes, we can ignore this case for
+            #       background publishing.
             self._flow_publish(settings, item)
+            return None
+
+        # Exit early if in the live session part of a bg-enabled publish
+        if self._is_deferred_to_bg(item):
+            self.logger.info(
+                "Background publish enabled — deferring publish registration to the background process."
+            )
             return None
 
         # ---- determine the information required to publish
@@ -472,6 +482,13 @@ class BasicFilePublishPlugin(HookBaseClass):
         publisher = self.parent
 
         if self._flow_active():
+            return None
+
+        # Exit early if in the live session part of a bg-enabled publish
+        if self._is_deferred_to_bg(item):
+            self.logger.info(
+                "Background publish enabled — deferring finalize to the background process."
+            )
             return None
 
         # get the data for the publish that was just created in PTR

--- a/hooks/publish_file.py
+++ b/hooks/publish_file.py
@@ -379,17 +379,7 @@ class BasicFilePublishPlugin(HookBaseClass):
 
         # -- Flow AM: publish to Flow AM, then continue to SG register_publish
         if self._flow_active():
-            # NOTE: Because we are checking during validation step that bg publish is
-            #       not enabled for flow publishes, we can ignore this case for
-            #       background publishing.
             self._flow_publish(settings, item)
-            return None
-
-        # Exit early if in the live session part of a bg-enabled publish
-        if self._is_deferred_to_bg(item):
-            self.logger.info(
-                "Background publish enabled — deferring publish registration to the background process."
-            )
             return None
 
         # ---- determine the information required to publish
@@ -482,13 +472,6 @@ class BasicFilePublishPlugin(HookBaseClass):
         publisher = self.parent
 
         if self._flow_active():
-            return None
-
-        # Exit early if in the live session part of a bg-enabled publish
-        if self._is_deferred_to_bg(item):
-            self.logger.info(
-                "Background publish enabled — deferring finalize to the background process."
-            )
             return None
 
         # get the data for the publish that was just created in PTR

--- a/hooks/publish_file.py
+++ b/hooks/publish_file.py
@@ -167,9 +167,7 @@ class BasicFilePublishPlugin(HookBaseClass):
         A file can be published multiple times however only the most recent
         publish will be available to other users. Warnings will be provided
         during validation if there are previous publishes.
-        """ % (
-            loader_url,
-        )
+        """ % (loader_url,)
 
     @property
     def settings(self):

--- a/hooks/upload_version.py
+++ b/hooks/upload_version.py
@@ -241,81 +241,86 @@ class UploadVersionPlugin(HookBaseClass):
         :param item: Item to process
         """
 
-        publisher = self.parent
-        path = item.properties["path"]
-
-        # allow the publish name to be supplied via the item properties. this is
-        # useful for collectors that have access to templates and can determine
-        # publish information about the item that doesn't require further, fuzzy
-        # logic to be used here (the zero config way)
-        publish_name = item.properties.get("publish_name") or item.properties.get(
-            "publish_version_name"
-        )
-        if not publish_name:
-
-            self.logger.debug("Using path info hook to determine publish name.")
-
-            # use the path's filename as the publish name
-            path_components = publisher.util.get_file_path_components(path)
-            publish_name = path_components["filename"]
-
-        self.logger.debug("Publish name: %s" % (publish_name,))
-
-        self.logger.info("Creating Version...")
-        version_data = {
-            "project": item.context.project,
-            "code": publish_name,
-            "description": item.description,
-            "entity": self._get_version_entity(item),
-            "sg_task": item.context.task,
-        }
-
-        if "sg_publish_data" in item.properties:
-            publish_data = item.properties["sg_publish_data"]
-            version_data["published_files"] = [publish_data]
-
-        if settings["Link Local File"].value:
-            version_data["sg_path_to_movie"] = path
-
-        # log the version data for debugging
-        self.logger.debug(
-            "Populated Version data...",
-            extra={
-                "action_show_more_info": {
-                    "label": "Version Data",
-                    "tooltip": "Show the complete Version data dictionary",
-                    "text": "<pre>%s</pre>" % (pprint.pformat(version_data),),
-                }
-            },
-        )
-
-        # Create the version
-        version = publisher.shotgun.create("Version", version_data)
-        self.logger.info("Version created!")
-
-        # stash the version info in the item just in case
-        item.properties["sg_version_data"] = version
-
-        thumb = item.get_thumbnail_as_path()
-
-        if settings["Upload"].value:
-            self.logger.info("Uploading content...")
-
-            if sgtk.util.is_windows():
-                upload_path = str(path)
-            else:
-                upload_path = path
-
-            self.parent.shotgun.upload(
-                "Version", version["id"], upload_path, "sg_uploaded_movie"
+        if self._is_deferred_to_bg(item):
+            self.logger.info(
+                "Background publish enabled — deferring version upload to the background process."
             )
-        elif thumb:
-            # only upload thumb if we are not uploading the content. with
-            # uploaded content, the thumb is automatically extracted.
-            self.logger.info("Uploading thumbnail...")
-            self.parent.shotgun.upload_thumbnail("Version", version["id"], thumb)
+        else:
+            publisher = self.parent
+            path = item.properties["path"]
 
-        self.logger.info("Upload complete!")
+            # allow the publish name to be supplied via the item properties. this is
+            # useful for collectors that have access to templates and can determine
+            # publish information about the item that doesn't require further, fuzzy
+            # logic to be used here (the zero config way)
+            publish_name = item.properties.get("publish_name") or item.properties.get(
+                "publish_version_name"
+            )
+            if not publish_name:
+
+                self.logger.debug("Using path info hook to determine publish name.")
+
+                # use the path's filename as the publish name
+                path_components = publisher.util.get_file_path_components(path)
+                publish_name = path_components["filename"]
+
+            self.logger.debug("Publish name: %s" % (publish_name,))
+
+            self.logger.info("Creating Version...")
+            version_data = {
+                "project": item.context.project,
+                "code": publish_name,
+                "description": item.description,
+                "entity": self._get_version_entity(item),
+                "sg_task": item.context.task,
+            }
+
+            if "sg_publish_data" in item.properties:
+                publish_data = item.properties["sg_publish_data"]
+                version_data["published_files"] = [publish_data]
+
+            if settings["Link Local File"].value:
+                version_data["sg_path_to_movie"] = path
+
+            # log the version data for debugging
+            self.logger.debug(
+                "Populated Version data...",
+                extra={
+                    "action_show_more_info": {
+                        "label": "Version Data",
+                        "tooltip": "Show the complete Version data dictionary",
+                        "text": "<pre>%s</pre>" % (pprint.pformat(version_data),),
+                    }
+                },
+            )
+
+            # Create the version
+            version = publisher.shotgun.create("Version", version_data)
+            self.logger.info("Version created!")
+
+            # stash the version info in the item just in case
+            item.properties["sg_version_data"] = version
+
+            thumb = item.get_thumbnail_as_path()
+
+            if settings["Upload"].value:
+                self.logger.info("Uploading content...")
+
+                if sgtk.util.is_windows():
+                    upload_path = str(path)
+                else:
+                    upload_path = path
+
+                self.parent.shotgun.upload(
+                    "Version", version["id"], upload_path, "sg_uploaded_movie"
+                )
+            elif thumb:
+                # only upload thumb if we are not uploading the content. with
+                # uploaded content, the thumb is automatically extracted.
+                self.logger.info("Uploading thumbnail...")
+                self.parent.shotgun.upload_thumbnail("Version", version["id"], thumb)
+
+            self.logger.info("Upload complete!")
 
     def finalize(self, settings, item):
         """
@@ -328,19 +333,24 @@ class UploadVersionPlugin(HookBaseClass):
         :param item: Item to process
         """
 
-        path = item.properties["path"]
-        version = item.properties["sg_version_data"]
+        if self._is_deferred_to_bg(item):
+            self.logger.info(
+                "Background publish enabled — deferring version upload finalize to the background process."
+            )
+        else:
+            path = item.properties["path"]
+            version = item.properties["sg_version_data"]
 
-        self.logger.info(
-            "Version uploaded for file: %s" % (path,),
-            extra={
-                "action_show_in_shotgun": {
-                    "label": "Show Version",
-                    "tooltip": "Reveal the version in Flow Production Tracking.",
-                    "entity": version,
-                }
-            },
-        )
+            self.logger.info(
+                "Version uploaded for file: %s" % (path,),
+                extra={
+                    "action_show_in_shotgun": {
+                        "label": "Show Version",
+                        "tooltip": "Reveal the version in Flow Production Tracking.",
+                        "entity": version,
+                    }
+                },
+            )
 
     def _get_version_entity(self, item):
         """
@@ -399,3 +409,14 @@ class UploadVersionPlugin(HookBaseClass):
             publish_type = "Folder"
 
         return publish_type
+
+    def _is_deferred_to_bg(self, item) -> bool:
+        """Return True if publish item or any ancestor of it has bg publish enabled
+        but we are not currently in a bg process.
+        """
+        root = item
+        while not root.is_root:
+            root = root.parent
+        return bool(root.properties.get("bg_processing")) and not bool(
+            root.properties.get("in_bg_process")
+        )


### PR DESCRIPTION
**Problem:**
After configuring and enabling background publish in Maya, the main publish plugin "Publish to Flow Production Tracking" was executing entirely in the foreground process.

**Root Causes:**
There were two root causes discovered during the investigation.

1. Maya standalone was not being initialized in the right sequence within the run_publish_process.py in tk-multi-bg-publish causing an early exit of the background process.
(Handled in https://github.com/shotgunsoftware/tk-multi-bg-publish/pull/23)
3. Neither the Maya nor base publish processes were instrumented with the correct gating to support deferring appropriate parts of the publish process to the background process.
(Handled in this PR as well as https://github.com/shotgunsoftware/tk-maya/pull/131)

**What's in this PR?**
This PR contains the necessary gating within the base publish process to support background publishing.
**NOTE:**  for now, this does not apply to Flow publishes for which background publishing has been disallowed.
Proper support for background publishing with Flow integration requires further thought and planning, and a separate work item.

**Details:**
- for now, disallow bg publish if project is Flow enabled (need to build support for that separatedly)
- properly defer publish process to bg process if bg publish enabled
- properly defer finalize process to bg process if bg publish enabled

